### PR TITLE
feat: add agent watch command for real-time monitoring

### DIFF
--- a/src/cli/commands/agent-watch.ts
+++ b/src/cli/commands/agent-watch.ts
@@ -1,0 +1,140 @@
+/**
+ * Agent watch command - Monitor agent activity in real-time
+ */
+
+import type { AgentStackConfig, SpawnedAgent, AgentStatus } from '../../types.js';
+import { listAgents, getConcurrencyStats } from '../../agents/spawner.js';
+import { WatchRenderer, type AgentWatchData } from '../utils/watch-renderer.js';
+import { hideCursor, showCursor, clearScreen } from '../utils/terminal.js';
+
+export interface AgentWatchOptions {
+  interval: string;
+  session?: string;
+  type?: string;
+  status?: string;
+  json: boolean;
+  clear: boolean;
+}
+
+/**
+ * Run the agent watch command
+ */
+export async function runAgentWatch(
+  options: AgentWatchOptions,
+  _config: AgentStackConfig
+): Promise<void> {
+  const interval = parseInt(options.interval, 10) * 1000;
+
+  if (isNaN(interval) || interval < 1000) {
+    console.error('Error: Interval must be at least 1 second');
+    process.exit(1);
+  }
+
+  // JSON mode - single snapshot
+  if (options.json) {
+    const data = collectAgentData(options);
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  // Interactive watch mode
+  const renderer = new WatchRenderer({
+    clearScreen: options.clear,
+  });
+
+  // Setup cleanup handler
+  let running = true;
+  const cleanup = (): void => {
+    running = false;
+    showCursor();
+    if (options.clear) {
+      clearScreen();
+    }
+    console.log('\nWatch stopped.');
+    process.exit(0);
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  // Hide cursor during watch mode
+  hideCursor();
+
+  // Initial render
+  try {
+    const data = collectAgentData(options);
+    renderer.render(data);
+  } catch (error) {
+    showCursor();
+    console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
+    process.exit(1);
+  }
+
+  // Set up refresh interval
+  const intervalId = setInterval(() => {
+    if (!running) {
+      clearInterval(intervalId);
+      return;
+    }
+
+    try {
+      const data = collectAgentData(options);
+      renderer.render(data);
+    } catch (error) {
+      // Log error but continue watching
+      console.error(`Refresh error: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }, interval);
+}
+
+/**
+ * Collect agent data for display
+ */
+function collectAgentData(options: AgentWatchOptions): AgentWatchData {
+  // Get all agents, optionally filtered by session
+  let agents = listAgents(options.session);
+
+  // Filter by type
+  if (options.type) {
+    agents = agents.filter((agent) => agent.type === options.type);
+  }
+
+  // Filter by status
+  if (options.status) {
+    agents = agents.filter((agent) => agent.status === options.status);
+  }
+
+  // Get concurrency stats
+  const concurrencyStats = getConcurrencyStats();
+
+  // Calculate status counts
+  const byStatus = countByStatus(agents);
+
+  return {
+    agents,
+    stats: {
+      active: concurrencyStats.agents.active,
+      maxConcurrent: concurrencyStats.agents.maxConcurrent,
+      byStatus,
+    },
+  };
+}
+
+/**
+ * Count agents by status
+ */
+function countByStatus(agents: SpawnedAgent[]): Record<AgentStatus, number> {
+  const counts: Record<AgentStatus, number> = {
+    idle: 0,
+    running: 0,
+    completed: 0,
+    failed: 0,
+    stopped: 0,
+  };
+
+  for (const agent of agents) {
+    counts[agent.status] = (counts[agent.status] || 0) + 1;
+  }
+
+  return counts;
+}

--- a/src/cli/commands/agent.ts
+++ b/src/cli/commands/agent.ts
@@ -17,6 +17,7 @@ import {
 import { listAgentTypes, getAgentDefinition } from '../../agents/registry.js';
 import { getConfig } from '../../utils/config.js';
 import { readFileSync, existsSync } from 'node:fs';
+import { runAgentWatch, type AgentWatchOptions } from './agent-watch.js';
 
 export function createAgentCommand(): Command {
   const command = new Command('agent')
@@ -176,6 +177,21 @@ export function createAgentCommand(): Command {
         const def = getAgentDefinition(type);
         console.log(`${type.padEnd(14)}${def?.description ?? ''}`);
       }
+    });
+
+  // watch subcommand
+  command
+    .command('watch')
+    .description('Watch agent activity in real-time')
+    .option('-i, --interval <seconds>', 'Refresh interval in seconds', '2')
+    .option('-s, --session <id>', 'Filter by session ID')
+    .option('-t, --type <type>', 'Filter by agent type')
+    .option('--status <status>', 'Filter by status (idle, running, completed, failed, stopped)')
+    .option('--json', 'Output as JSON snapshot (no watch)')
+    .option('--no-clear', 'Do not clear screen between refreshes')
+    .action(async (options) => {
+      const config = getConfig();
+      await runAgentWatch(options as AgentWatchOptions, config);
     });
 
   // run subcommand - execute a task with an agent

--- a/src/cli/utils/terminal.ts
+++ b/src/cli/utils/terminal.ts
@@ -1,0 +1,148 @@
+/**
+ * Terminal formatting utilities for CLI output
+ */
+
+import type { AgentStatus } from '../../types.js';
+
+// ANSI color codes
+export const colors = {
+  reset: '\x1b[0m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+
+  // Foreground colors
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  gray: '\x1b[90m',
+  cyan: '\x1b[36m',
+  white: '\x1b[37m',
+} as const;
+
+/**
+ * Format duration from milliseconds to human-readable string
+ * @param ms Duration in milliseconds
+ * @returns Formatted string like "2m 34s"
+ */
+export function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const hours = Math.floor(minutes / 60);
+
+  if (hours > 0) {
+    return `${hours}h ${minutes % 60}m`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds % 60}s`;
+  }
+  return `${seconds}s`;
+}
+
+/**
+ * Get status indicator icon
+ */
+export function statusIcon(status: AgentStatus): string {
+  switch (status) {
+    case 'running':
+      return '\u25cf'; // ● filled circle
+    case 'idle':
+      return '\u25cb'; // ○ empty circle
+    case 'completed':
+      return '\u2713'; // ✓ check mark
+    case 'failed':
+      return '\u2717'; // ✗ x mark
+    case 'stopped':
+      return '\u25a0'; // ■ filled square
+    default:
+      return '?';
+  }
+}
+
+/**
+ * Get ANSI color for status
+ */
+export function statusColor(status: AgentStatus): string {
+  switch (status) {
+    case 'running':
+      return colors.green;
+    case 'idle':
+      return colors.yellow;
+    case 'completed':
+      return colors.green;
+    case 'failed':
+      return colors.red;
+    case 'stopped':
+      return colors.gray;
+    default:
+      return colors.white;
+  }
+}
+
+/**
+ * Get short status label
+ */
+export function statusLabel(status: AgentStatus): string {
+  switch (status) {
+    case 'running':
+      return 'RUN';
+    case 'idle':
+      return 'IDLE';
+    case 'completed':
+      return 'DONE';
+    case 'failed':
+      return 'FAIL';
+    case 'stopped':
+      return 'STOP';
+  }
+}
+
+/**
+ * Truncate text to max length with ellipsis
+ */
+export function truncate(text: string, maxLen: number): string {
+  if (text.length <= maxLen) {
+    return text;
+  }
+  return text.slice(0, maxLen - 1) + '\u2026'; // ellipsis character
+}
+
+/**
+ * Pad string to exact width (truncates if necessary)
+ */
+export function padToWidth(text: string, width: number): string {
+  const truncated = truncate(text, width);
+  return truncated.padEnd(width);
+}
+
+/**
+ * Clear the terminal screen
+ */
+export function clearScreen(): void {
+  process.stdout.write('\x1b[2J\x1b[H');
+}
+
+/**
+ * Hide cursor
+ */
+export function hideCursor(): void {
+  process.stdout.write('\x1b[?25l');
+}
+
+/**
+ * Show cursor
+ */
+export function showCursor(): void {
+  process.stdout.write('\x1b[?25h');
+}
+
+/**
+ * Format current time as HH:MM:SS
+ */
+export function formatTime(date: Date = new Date()): string {
+  return date.toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}

--- a/src/cli/utils/watch-renderer.ts
+++ b/src/cli/utils/watch-renderer.ts
@@ -1,0 +1,194 @@
+/**
+ * Watch display renderer for agent monitoring
+ */
+
+import type { SpawnedAgent, AgentStatus } from '../../types.js';
+import {
+  colors,
+  formatDuration,
+  formatTime,
+  statusIcon,
+  statusColor,
+  statusLabel,
+  padToWidth,
+  clearScreen,
+} from './terminal.js';
+
+export interface AgentWatchData {
+  agents: SpawnedAgent[];
+  stats: {
+    active: number;
+    maxConcurrent: number;
+    byStatus: Record<AgentStatus, number>;
+  };
+}
+
+export interface WatchRendererOptions {
+  clearScreen: boolean;
+}
+
+/**
+ * Renderer for the agent watch display
+ */
+export class WatchRenderer {
+  private options: WatchRendererOptions;
+
+  constructor(options: Partial<WatchRendererOptions> = {}) {
+    this.options = {
+      clearScreen: options.clearScreen ?? true,
+    };
+  }
+
+  /**
+   * Render the full watch display
+   */
+  render(data: AgentWatchData): void {
+    if (this.options.clearScreen) {
+      clearScreen();
+    }
+
+    this.renderHeader();
+    this.renderSummary(data);
+    this.renderAgentTable(data.agents);
+    this.renderFooter();
+  }
+
+  /**
+   * Render header with timestamp
+   */
+  private renderHeader(): void {
+    const title = 'AISTACK Agent Monitor';
+    const timestamp = `Last updated: ${formatTime()}`;
+    const width = 75;
+
+    // Title line with timestamp right-aligned
+    const padding = width - title.length - timestamp.length;
+    console.log(
+      `${colors.bold}${title}${colors.reset}${' '.repeat(Math.max(1, padding))}${colors.dim}${timestamp}${colors.reset}`
+    );
+
+    // Double line separator
+    console.log('\u2550'.repeat(width));
+  }
+
+  /**
+   * Render agent count summary
+   */
+  private renderSummary(data: AgentWatchData): void {
+    const { stats } = data;
+    const statusCounts: string[] = [];
+
+    // Build status breakdown
+    const statusOrder: AgentStatus[] = ['running', 'idle', 'failed', 'completed', 'stopped'];
+    for (const status of statusOrder) {
+      const count = stats.byStatus[status] || 0;
+      if (count > 0) {
+        statusCounts.push(`${count} ${status}`);
+      }
+    }
+
+    const breakdown = statusCounts.length > 0 ? ` (${statusCounts.join(', ')})` : '';
+    const agentInfo = `Agents: ${colors.bold}${stats.active}${colors.reset} active${breakdown}`;
+    const limitInfo = `${colors.dim}Limit: ${stats.maxConcurrent}${colors.reset}`;
+
+    const width = 75;
+    const padding = width - stripAnsi(agentInfo).length - stripAnsi(limitInfo).length;
+
+    console.log(`${agentInfo}${' '.repeat(Math.max(1, padding))}${limitInfo}`);
+
+    // Single line separator
+    console.log('\u2500'.repeat(width));
+  }
+
+  /**
+   * Render agent list table
+   */
+  private renderAgentTable(agents: SpawnedAgent[]): void {
+    if (agents.length === 0) {
+      console.log(`${colors.dim}No active agents${colors.reset}`);
+      console.log('');
+      console.log(`${colors.dim}Spawn agents with: aistack agent spawn -t <type>${colors.reset}`);
+      return;
+    }
+
+    // Table header
+    console.log(
+      `${colors.dim}STATUS   NAME                 TYPE         UPTIME     TASK${colors.reset}`
+    );
+
+    // Sort agents: running first, then by creation time
+    const sortedAgents = [...agents].sort((a, b) => {
+      if (a.status === 'running' && b.status !== 'running') return -1;
+      if (a.status !== 'running' && b.status === 'running') return 1;
+      return b.createdAt.getTime() - a.createdAt.getTime();
+    });
+
+    for (const agent of sortedAgents) {
+      this.renderAgentRow(agent);
+    }
+  }
+
+  /**
+   * Render a single agent row
+   */
+  private renderAgentRow(agent: SpawnedAgent): void {
+    const color = statusColor(agent.status);
+    const icon = statusIcon(agent.status);
+    const label = statusLabel(agent.status);
+    const uptime = formatDuration(Date.now() - agent.createdAt.getTime());
+    const task = this.getAgentTask(agent);
+
+    // Format: icon label  name  type  uptime  task
+    const statusCol = `${color}${icon} ${label}${colors.reset}`;
+    const nameCol = padToWidth(agent.name, 20);
+    const typeCol = padToWidth(agent.type, 12);
+    const uptimeCol = padToWidth(uptime, 10);
+    const taskCol = task;
+
+    console.log(`${statusCol}  ${nameCol} ${typeCol} ${uptimeCol} ${taskCol}`);
+  }
+
+  /**
+   * Get task description for agent
+   */
+  private getAgentTask(agent: SpawnedAgent): string {
+    // Check metadata for current task
+    const activity = agent.metadata?.activity as { currentTask?: string } | undefined;
+    if (activity?.currentTask) {
+      return activity.currentTask;
+    }
+
+    // Default based on status
+    switch (agent.status) {
+      case 'running':
+        return `${colors.dim}Processing...${colors.reset}`;
+      case 'failed':
+        const error = agent.metadata?.lastError as string | undefined;
+        return error ? `${colors.red}Error: ${error}${colors.reset}` : `${colors.red}Error${colors.reset}`;
+      case 'idle':
+        return `${colors.dim}\u2014${colors.reset}`; // em dash
+      case 'completed':
+        return `${colors.green}Done${colors.reset}`;
+      case 'stopped':
+        return `${colors.dim}Stopped${colors.reset}`;
+      default:
+        return `${colors.dim}\u2014${colors.reset}`;
+    }
+  }
+
+  /**
+   * Render footer
+   */
+  private renderFooter(): void {
+    console.log('\u2500'.repeat(75));
+    console.log(`${colors.dim}Press Ctrl+C to exit${colors.reset}`);
+  }
+}
+
+/**
+ * Strip ANSI codes from string (for length calculation)
+ */
+function stripAnsi(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*m/g, '');
+}

--- a/tests/unit/cli/agent-watch.test.ts
+++ b/tests/unit/cli/agent-watch.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Tests for agent watch command
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runAgentWatch } from '../../../src/cli/commands/agent-watch.js';
+import * as spawner from '../../../src/agents/spawner.js';
+import type { AgentStackConfig, SpawnedAgent } from '../../../src/types.js';
+
+// Mock the spawner module
+vi.mock('../../../src/agents/spawner.js', () => ({
+  listAgents: vi.fn(),
+  getConcurrencyStats: vi.fn(),
+}));
+
+describe('Agent Watch Command', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let processExitSpy: ReturnType<typeof vi.spyOn>;
+
+  const mockConfig: AgentStackConfig = {
+    version: '1.0.0',
+    memory: {
+      path: '/tmp/test.db',
+      defaultNamespace: 'test',
+      vectorSearch: { enabled: false },
+    },
+    providers: { default: 'anthropic' },
+    agents: { maxConcurrent: 20, defaultTimeout: 30000 },
+    github: { enabled: false },
+    plugins: { enabled: false, directory: './plugins' },
+    mcp: { transport: 'stdio' },
+    hooks: { sessionStart: false, sessionEnd: false, preTask: false, postTask: false },
+  };
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    processExitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+    vi.mocked(spawner.listAgents).mockReturnValue([]);
+    vi.mocked(spawner.getConcurrencyStats).mockReturnValue({
+      agents: { active: 0, maxConcurrent: 20, byType: {} },
+      semaphore: { available: 20, maxPermits: 20, queued: 0 },
+      pool: {},
+    });
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    processExitSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  describe('JSON mode', () => {
+    it('should output JSON snapshot and exit', async () => {
+      const options = {
+        interval: '2',
+        json: true,
+        clear: true,
+      };
+
+      await runAgentWatch(options, mockConfig);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const output = consoleSpy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+      expect(parsed).toHaveProperty('agents');
+      expect(parsed).toHaveProperty('stats');
+      expect(parsed.stats).toHaveProperty('active');
+      expect(parsed.stats).toHaveProperty('maxConcurrent');
+    });
+
+    it('should include agents in JSON output', async () => {
+      const mockAgent: SpawnedAgent = {
+        id: 'test-id',
+        type: 'coder',
+        name: 'test-coder',
+        status: 'running',
+        createdAt: new Date(),
+      };
+
+      vi.mocked(spawner.listAgents).mockReturnValue([mockAgent]);
+      vi.mocked(spawner.getConcurrencyStats).mockReturnValue({
+        agents: { active: 1, maxConcurrent: 20, byType: { coder: 1 } },
+        semaphore: { available: 19, maxPermits: 20, queued: 0 },
+        pool: {},
+      });
+
+      const options = {
+        interval: '2',
+        json: true,
+        clear: true,
+      };
+
+      await runAgentWatch(options, mockConfig);
+
+      const output = consoleSpy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+      expect(parsed.agents).toHaveLength(1);
+      expect(parsed.agents[0].name).toBe('test-coder');
+    });
+  });
+
+  describe('filtering', () => {
+    it('should filter by session', async () => {
+      const options = {
+        interval: '2',
+        session: 'session-123',
+        json: true,
+        clear: true,
+      };
+
+      await runAgentWatch(options, mockConfig);
+
+      expect(spawner.listAgents).toHaveBeenCalledWith('session-123');
+    });
+
+    it('should filter by type', async () => {
+      const agents: SpawnedAgent[] = [
+        { id: '1', type: 'coder', name: 'coder-1', status: 'idle', createdAt: new Date() },
+        { id: '2', type: 'tester', name: 'tester-1', status: 'idle', createdAt: new Date() },
+      ];
+
+      vi.mocked(spawner.listAgents).mockReturnValue(agents);
+
+      const options = {
+        interval: '2',
+        type: 'coder',
+        json: true,
+        clear: true,
+      };
+
+      await runAgentWatch(options, mockConfig);
+
+      const output = consoleSpy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+      expect(parsed.agents).toHaveLength(1);
+      expect(parsed.agents[0].type).toBe('coder');
+    });
+
+    it('should filter by status', async () => {
+      const agents: SpawnedAgent[] = [
+        { id: '1', type: 'coder', name: 'coder-1', status: 'running', createdAt: new Date() },
+        { id: '2', type: 'coder', name: 'coder-2', status: 'idle', createdAt: new Date() },
+      ];
+
+      vi.mocked(spawner.listAgents).mockReturnValue(agents);
+
+      const options = {
+        interval: '2',
+        status: 'running',
+        json: true,
+        clear: true,
+      };
+
+      await runAgentWatch(options, mockConfig);
+
+      const output = consoleSpy.mock.calls[0][0];
+      const parsed = JSON.parse(output);
+      expect(parsed.agents).toHaveLength(1);
+      expect(parsed.agents[0].status).toBe('running');
+    });
+  });
+
+  describe('validation', () => {
+    it('should reject invalid interval', async () => {
+      const options = {
+        interval: 'abc',
+        json: false,
+        clear: true,
+      };
+
+      await runAgentWatch(options, mockConfig);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Interval must be at least 1 second');
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+
+    it('should reject interval less than 1 second', async () => {
+      const options = {
+        interval: '0',
+        json: false,
+        clear: true,
+      };
+
+      await runAgentWatch(options, mockConfig);
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith('Error: Interval must be at least 1 second');
+      expect(processExitSpy).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/tests/unit/cli/terminal.test.ts
+++ b/tests/unit/cli/terminal.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for terminal utilities
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatDuration,
+  statusIcon,
+  statusColor,
+  statusLabel,
+  truncate,
+  padToWidth,
+  formatTime,
+  colors,
+} from '../../../src/cli/utils/terminal.js';
+
+describe('Terminal Utilities', () => {
+  describe('formatDuration', () => {
+    it('should format seconds', () => {
+      expect(formatDuration(5000)).toBe('5s');
+      expect(formatDuration(45000)).toBe('45s');
+    });
+
+    it('should format minutes and seconds', () => {
+      expect(formatDuration(65000)).toBe('1m 5s');
+      expect(formatDuration(150000)).toBe('2m 30s');
+    });
+
+    it('should format hours and minutes', () => {
+      expect(formatDuration(3665000)).toBe('1h 1m');
+      expect(formatDuration(7200000)).toBe('2h 0m');
+    });
+
+    it('should handle zero', () => {
+      expect(formatDuration(0)).toBe('0s');
+    });
+  });
+
+  describe('statusIcon', () => {
+    it('should return correct icons for each status', () => {
+      expect(statusIcon('running')).toBe('\u25cf');
+      expect(statusIcon('idle')).toBe('\u25cb');
+      expect(statusIcon('completed')).toBe('\u2713');
+      expect(statusIcon('failed')).toBe('\u2717');
+      expect(statusIcon('stopped')).toBe('\u25a0');
+    });
+  });
+
+  describe('statusColor', () => {
+    it('should return correct colors for each status', () => {
+      expect(statusColor('running')).toBe(colors.green);
+      expect(statusColor('idle')).toBe(colors.yellow);
+      expect(statusColor('completed')).toBe(colors.green);
+      expect(statusColor('failed')).toBe(colors.red);
+      expect(statusColor('stopped')).toBe(colors.gray);
+    });
+  });
+
+  describe('statusLabel', () => {
+    it('should return correct labels for each status', () => {
+      expect(statusLabel('running')).toBe('RUN');
+      expect(statusLabel('idle')).toBe('IDLE');
+      expect(statusLabel('completed')).toBe('DONE');
+      expect(statusLabel('failed')).toBe('FAIL');
+      expect(statusLabel('stopped')).toBe('STOP');
+    });
+  });
+
+  describe('truncate', () => {
+    it('should not truncate short strings', () => {
+      expect(truncate('hello', 10)).toBe('hello');
+    });
+
+    it('should truncate long strings with ellipsis', () => {
+      expect(truncate('hello world', 8)).toBe('hello w\u2026');
+    });
+
+    it('should handle exact length', () => {
+      expect(truncate('hello', 5)).toBe('hello');
+    });
+  });
+
+  describe('padToWidth', () => {
+    it('should pad short strings', () => {
+      expect(padToWidth('hi', 5)).toBe('hi   ');
+    });
+
+    it('should truncate and pad long strings', () => {
+      expect(padToWidth('hello world', 8)).toBe('hello w\u2026');
+    });
+  });
+
+  describe('formatTime', () => {
+    it('should format time as HH:MM:SS', () => {
+      const date = new Date('2024-01-15T14:32:45');
+      const result = formatTime(date);
+      expect(result).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    });
+  });
+});

--- a/tests/unit/cli/watch-renderer.test.ts
+++ b/tests/unit/cli/watch-renderer.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Tests for watch renderer
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WatchRenderer, type AgentWatchData } from '../../../src/cli/utils/watch-renderer.js';
+import type { SpawnedAgent } from '../../../src/types.js';
+
+describe('WatchRenderer', () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    stdoutSpy.mockRestore();
+  });
+
+  function createMockAgent(overrides: Partial<SpawnedAgent> = {}): SpawnedAgent {
+    return {
+      id: 'test-agent-id',
+      type: 'coder',
+      name: 'coder-12345678',
+      status: 'idle',
+      createdAt: new Date(Date.now() - 60000), // 1 minute ago
+      ...overrides,
+    };
+  }
+
+  function createMockData(agents: SpawnedAgent[] = []): AgentWatchData {
+    return {
+      agents,
+      stats: {
+        active: agents.length,
+        maxConcurrent: 20,
+        byStatus: {
+          idle: agents.filter(a => a.status === 'idle').length,
+          running: agents.filter(a => a.status === 'running').length,
+          completed: agents.filter(a => a.status === 'completed').length,
+          failed: agents.filter(a => a.status === 'failed').length,
+          stopped: agents.filter(a => a.status === 'stopped').length,
+        },
+      },
+    };
+  }
+
+  describe('render', () => {
+    it('should render without agents', () => {
+      const renderer = new WatchRenderer({ clearScreen: false });
+      const data = createMockData([]);
+
+      renderer.render(data);
+
+      expect(consoleSpy).toHaveBeenCalled();
+      const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('AISTACK Agent Monitor');
+      expect(output).toContain('No active agents');
+    });
+
+    it('should render with agents', () => {
+      const renderer = new WatchRenderer({ clearScreen: false });
+      const agents = [
+        createMockAgent({ status: 'running', name: 'coder-running' }),
+        createMockAgent({ status: 'idle', name: 'tester-idle', type: 'tester' }),
+      ];
+      const data = createMockData(agents);
+
+      renderer.render(data);
+
+      const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('AISTACK Agent Monitor');
+      expect(output).toContain('Agents:');
+      expect(output).toContain('coder-running');
+      expect(output).toContain('tester-idle');
+    });
+
+    it('should sort running agents first', () => {
+      const renderer = new WatchRenderer({ clearScreen: false });
+      const agents = [
+        createMockAgent({ status: 'idle', name: 'agent-idle', createdAt: new Date() }),
+        createMockAgent({ status: 'running', name: 'agent-running', createdAt: new Date(Date.now() - 5000) }),
+      ];
+      const data = createMockData(agents);
+
+      renderer.render(data);
+
+      const calls = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+      const runningIndex = calls.indexOf('agent-running');
+      const idleIndex = calls.indexOf('agent-idle');
+      expect(runningIndex).toBeLessThan(idleIndex);
+    });
+
+    it('should clear screen when option is set', () => {
+      const renderer = new WatchRenderer({ clearScreen: true });
+      const data = createMockData([]);
+
+      renderer.render(data);
+
+      expect(stdoutSpy).toHaveBeenCalledWith('\x1b[2J\x1b[H');
+    });
+
+    it('should not clear screen when option is false', () => {
+      const renderer = new WatchRenderer({ clearScreen: false });
+      const data = createMockData([]);
+
+      renderer.render(data);
+
+      expect(stdoutSpy).not.toHaveBeenCalledWith('\x1b[2J\x1b[H');
+    });
+  });
+
+  describe('agent status display', () => {
+    it('should show status counts in summary', () => {
+      const renderer = new WatchRenderer({ clearScreen: false });
+      const agents = [
+        createMockAgent({ status: 'running' }),
+        createMockAgent({ status: 'running', name: 'agent-2' }),
+        createMockAgent({ status: 'idle', name: 'agent-3' }),
+        createMockAgent({ status: 'failed', name: 'agent-4' }),
+      ];
+      const data = createMockData(agents);
+
+      renderer.render(data);
+
+      const output = consoleSpy.mock.calls.map(c => c[0]).join('\n');
+      expect(output).toContain('4');
+      expect(output).toContain('active');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `aistack agent watch` command to monitor agent activity in real-time
- Create terminal formatting utilities for consistent CLI output
- Support filtering by session, type, and status
- Add JSON output mode for scripting integration

## New Files

| File | Description |
|------|-------------|
| `src/cli/utils/terminal.ts` | ANSI colors, duration formatting, status icons |
| `src/cli/utils/watch-renderer.ts` | Watch display renderer class |
| `src/cli/commands/agent-watch.ts` | Main watch command logic |

## Usage

```bash
# Watch all agents (refreshes every 2 seconds)
aistack agent watch

# Custom refresh interval
aistack agent watch -i 5

# Filter by type
aistack agent watch -t coder

# JSON snapshot for scripting
aistack agent watch --json
```

## Test plan

- [x] Build passes: `npm run build`
- [x] All tests pass: `npm test` (1479 tests)
- [x] Command help displays correctly: `aistack agent watch --help`
- [x] JSON output works: `aistack agent watch --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `watch` command for real-time agent monitoring with live dashboard updates.
  * Supports both interactive mode with periodic refresh and JSON snapshot output.
  * Filter agents by session, type, and status.
  * Configurable monitoring interval (minimum 1 second).

* **Tests**
  * Added comprehensive test coverage for watch functionality and terminal utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->