### PR TITLE
[AIG-652] Multi-machine federation (M3-24)

### DIFF
--- a/docs/FEDERATION.md
+++ b/docs/FEDERATION.md
@@ -1,0 +1,248 @@
+# Multi-Machine Federation (AIG-652)
+
+Aistack ships an opt-in federation layer that lets multiple nodes
+discover each other, advertise capabilities, and delegate task execution
+across machines. Federation is **disabled by default** - enabling it does
+not affect any other subsystem.
+
+The implementation is intentionally small and isolated:
+
+```
+src/federation/
+  types.ts        Public interfaces (NodeInfo, FederationConfig, ...)
+  discovery.ts    StaticDiscovery / MdnsDiscovery / RegistryDiscovery
+  routing.ts      TaskRouter (round-robin / least-loaded / capability-match)
+  transport.ts    FederationClient + mTLS credential management + sanitizer
+  server.ts       Minimal HTTP(S) server exposing the federation endpoints
+  index.ts        FederationManager + createFederation factory
+```
+
+## Protocol
+
+Federation speaks plain JSON over HTTPS. Two endpoints, both versioned
+under `/v1/federation`:
+
+### `GET /v1/federation/capabilities`
+
+Returns this node's `NodeInfo`:
+
+```json
+{
+  "nodeId": "9c0c…",
+  "name": "aistack-prod-eu-1",
+  "address": "https://10.0.1.4:8443",
+  "scheme": "https",
+  "capabilities": [
+    { "name": "coder", "enabled": true, "maxConcurrent": 4 },
+    { "name": "researcher", "enabled": true }
+  ],
+  "load": 0.31,
+  "tags": ["eu-west", "gpu"],
+  "version": "1.6.1"
+}
+```
+
+The capabilities document does **not** contain task input, source code,
+memory snippets, or any other sensitive material.
+
+### `POST /v1/federation/task`
+
+Body: a `TaskDelegation` (sanitized client-side):
+
+```json
+{
+  "taskId": "abc-123",
+  "agentType": "coder",
+  "input": "Refactor the auth middleware to support OIDC",
+  "hints": {
+    "requiredCapabilities": ["coder"],
+    "preferredTags": ["eu-west"],
+    "estimatedTokens": 8000
+  }
+}
+```
+
+Response: a `TaskDelegationResult`:
+
+```json
+{
+  "taskId": "abc-123",
+  "status": "completed",
+  "summary": "Patch applied in 3 files, 12 lines changed",
+  "executedBy": "9c0c…"
+}
+```
+
+Only the `taskId`, `agentType`, `input` (truncated to
+`maxInputLength`, default 4096 chars) and `hints` are sent. Every other
+key is stripped by `sanitizeDelegation`.
+
+## Configuration
+
+The federation slot is a sibling of the existing top-level slots in
+`aistack.config.json`. Default values are safe:
+
+```json
+{
+  "federation": {
+    "enabled": true,
+    "name": "aistack-prod-eu-1",
+    "discoveryMethod": "mdns",
+    "advertise": true,
+    "peers": ["https://10.0.1.5:8443", "https://10.0.1.6:8443"],
+    "registryUrl": "https://federation.example.com",
+    "mdnsServiceType": "_aistack._tcp.local",
+    "bindAddress": "0.0.0.0",
+    "bindPort": 8443,
+    "routingPolicy": "least-loaded",
+    "maxInputLength": 4096,
+    "requestTimeoutMs": 10000,
+    "tls": {
+      "certPath": "/etc/aistack/federation/node.crt",
+      "keyPath":  "/etc/aistack/federation/node.key",
+      "caPath":   "/etc/aistack/federation/ca.crt",
+      "requireClientCert": true
+    }
+  }
+}
+```
+
+### Discovery methods
+
+| Method     | Use case                                 | Optional dep      |
+|------------|------------------------------------------|-------------------|
+| `static`   | Air-gapped, tests, small clusters        | none              |
+| `mdns`     | LAN auto-discovery (Bonjour / zeroconf)  | `bonjour-service` |
+| `registry` | Central HTTP registry, multi-DC          | none              |
+
+When `mdns` is selected but `bonjour-service` is not installed, the
+discovery silently degrades to no-op and logs a one-time warning -
+aistack continues to run.
+
+### Routing policies
+
+`TaskRouter` ships three policies, all configurable per call:
+
+- `round-robin` - cycles through candidates that advertise the
+  requested capability.
+- `least-loaded` - picks the lowest-load candidate; ties broken by
+  round-robin.
+- `capability-match` - +2 per matching `preferredTag`, +1 per matching
+  hint key, tie-break by lower load.
+
+## Security model
+
+Federation transport defaults to **mutual TLS**. Each node loads:
+
+- `certPath` - the node's own certificate (PEM)
+- `keyPath`  - the node's private key (PEM)
+- `caPath`   - the trusted CA bundle (PEM)
+
+`requireClientCert` defaults to `true`. Connections from peers without a
+valid client certificate are refused with HTTP 401.
+
+If `tls.cert`/`tls.key` are absent, the server falls back to HTTP and
+logs a loud warning. This is **only** acceptable for local development
+and integration tests.
+
+A bearer-token fallback (`tls.bearerToken`) is provided for environments
+where PKI is not available. Bearer mode also logs a warning at startup
+and should not be used in production.
+
+### Key rotation
+
+Federation certificates can be rotated by:
+
+1. Issuing a new cert from your internal CA.
+2. Writing the new files to `certPath` / `keyPath`.
+3. Sending SIGINT to the `aistack federation join` process and
+   restarting it. There is no hot-reload by design - federation is a
+   control-plane service and the restart blip is acceptable.
+
+Short-lived certs (24-72 h) are recommended; pair with cert-manager or
+SPIRE for automation.
+
+### No-egress of sensitive data
+
+The federation protocol carries only **task metadata**: id, agent type,
+sanitized input, and routing hints. The transport layer enforces this in
+two ways:
+
+1. `sanitizeDelegation()` runs on every outbound `submitTask` and uses
+   an allowlist of keys. Unknown keys (`secrets`, `filePayload`, …) are
+   dropped before serialization.
+2. `maxInputLength` truncates oversized inputs (default 4096 chars).
+
+Memory entries, hook context, agent prompts, and source code are **never**
+serialized by the federation transport. If you need to share project
+files between nodes, use a separate mechanism (git, a shared object
+store, etc.) - federation is not a file transfer layer.
+
+## CLI
+
+```
+aistack federation status            Show current federation state
+aistack federation peers             List statically configured peers
+aistack federation join [--port N]   Start the node and join the cluster
+aistack federation leave             Documents the SIGINT shutdown path
+```
+
+`join` runs in the foreground; press Ctrl+C to leave.
+
+## Programmatic usage
+
+```ts
+import { createFederation } from '@blackms/aistack';
+
+const fed = createFederation(config.federation);
+fed.setLocalCapabilities([
+  { name: 'coder', enabled: true, maxConcurrent: 4 },
+]);
+fed.setTaskHandler(async (task) => {
+  // Hand off to the local coordinator / spawner
+  const result = await runLocally(task);
+  return { taskId: task.taskId, status: 'completed', summary: result.summary, executedBy: '' };
+});
+await fed.join();
+
+// Opt-in delegation - call this from your coordinator when you want
+// to spread work across the cluster.
+const decision = fed.delegateTask(task, 'least-loaded');
+if (decision.peer) {
+  const remote = await fed.submitTask(decision.peer, task);
+  console.log(remote.summary);
+} else {
+  // Run locally
+}
+```
+
+## CRDT / state replication
+
+State replication across nodes (memory, agent identities, projects) is
+intentionally **out of scope for v1**. Each node keeps its own SQLite
+store; only routing-relevant data is shared via the discovery layer.
+
+A follow-up issue will introduce CRDT-based replication for agent
+identities and shared memory namespaces (likely Yjs or Automerge). The
+federation transport already carries an `executedBy` field so that
+remote-produced artifacts can be traced once replication lands.
+
+## Troubleshooting
+
+| Symptom                                            | Likely cause / fix                                                    |
+|----------------------------------------------------|-----------------------------------------------------------------------|
+| `Federation transport is UNAUTHENTICATED`          | Set `federation.tls.certPath` / `keyPath` / `caPath`.                 |
+| `bonjour-service package is not installed`         | `npm install bonjour-service` if you want mDNS discovery.             |
+| `Federation submitTask 401`                        | Peer rejected our cert. Check that both nodes trust the same CA.      |
+| `Federation submitTask 400 invalid_payload`        | Your task hint shape is wrong; see `TaskDelegation` in `types.ts`.    |
+| `delegateTask` always returns `peer: null`         | No peer advertises the requested `agentType`. Check capability lists. |
+| Peer never appears in `aistack federation status`  | Discovery method mismatch (mDNS vs registry) - both nodes must agree. |
+
+## Test coverage
+
+- `tests/unit/federation/routing.test.ts` - exhaustive policy tests
+  (round-robin, least-loaded, capability-match, tie-break, capability
+  filtering).
+- `tests/integration/federation-3node.test.ts` - spins up three local
+  nodes, verifies routing from node A to node B or C, and verifies that
+  `sanitizeDelegation` strips unknown keys / truncates oversized input.

--- a/src/cli/commands/federation.ts
+++ b/src/cli/commands/federation.ts
@@ -1,0 +1,126 @@
+/**
+ * federation command - join/leave/status/peers for multi-machine federation.
+ *
+ * The command operates against an in-process FederationManager built from
+ * the active aistack config. `join` runs the manager until SIGINT (so the
+ * node can be addressed by peers); `status` and `peers` consult a
+ * one-shot manager that only inspects discovery + static peers without
+ * starting the server.
+ */
+
+import { Command } from 'commander';
+import { getConfig } from '../../utils/config.js';
+import {
+  createFederation,
+  FederationManager,
+  type FederationConfig,
+} from '../../federation/index.js';
+import { logger } from '../../utils/logger.js';
+
+const log = logger.child('cli:federation');
+
+function readFederationConfig(): FederationConfig {
+  const cfg = getConfig() as ReturnType<typeof getConfig> & { federation?: FederationConfig };
+  return (
+    cfg.federation ?? {
+      enabled: false,
+      discoveryMethod: 'static',
+      advertise: false,
+      peers: [],
+      routingPolicy: 'least-loaded',
+    }
+  );
+}
+
+export function createFederationCommand(): Command {
+  const command = new Command('federation').description('Manage multi-machine federation');
+
+  // join
+  command
+    .command('join')
+    .description('Join the federation and keep the node running until SIGINT')
+    .option('--port <port>', 'Override bindPort')
+    .option('--advertise', 'Force advertise=true regardless of config')
+    .action(async (options: { port?: string; advertise?: boolean }) => {
+      const cfg = readFederationConfig();
+      if (options.port) cfg.bindPort = Number.parseInt(options.port, 10);
+      if (options.advertise) cfg.advertise = true;
+      cfg.enabled = true;
+
+      const fed = createFederation(cfg);
+      try {
+        await fed.join();
+        const status = fed.status();
+        console.log('Joined federation:');
+        console.log(`  nodeId:      ${status.nodeId}`);
+        console.log(`  name:        ${status.name}`);
+        console.log(`  address:     ${status.address}`);
+        console.log(`  discovery:   ${status.discoveryMethod}`);
+        console.log('Press Ctrl+C to leave.');
+      } catch (err) {
+        console.error(`Failed to join federation: ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+
+      const shutdown = async (): Promise<void> => {
+        log.info('Caught SIGINT - leaving federation');
+        try {
+          await fed.leave();
+        } finally {
+          process.exit(0);
+        }
+      };
+      process.on('SIGINT', () => void shutdown());
+      process.on('SIGTERM', () => void shutdown());
+
+      // Keep alive
+      await new Promise<void>(() => undefined);
+    });
+
+  // leave
+  command
+    .command('leave')
+    .description('Leave the federation (signals the local node to stop)')
+    .action(() => {
+      // The join process is a foreground command; leave is a hint to the
+      // operator. We document the SIGINT path here.
+      console.log(
+        'To leave the federation, send SIGINT (Ctrl+C) to the `aistack federation join` process.'
+      );
+    });
+
+  // status
+  command
+    .command('status')
+    .description('Show federation status (does not start the server)')
+    .action(async () => {
+      const cfg = readFederationConfig();
+      const fed: FederationManager = createFederation(cfg);
+      const status = fed.status();
+      console.log('Federation status:');
+      console.log(`  enabled:     ${status.enabled}`);
+      console.log(`  nodeId:      ${status.nodeId}`);
+      console.log(`  name:        ${status.name}`);
+      console.log(`  address:     ${status.address}`);
+      console.log(`  discovery:   ${status.discoveryMethod}`);
+      console.log(`  knownPeers:  ${status.peers.length}`);
+    });
+
+  // peers
+  command
+    .command('peers')
+    .description('List statically configured peers')
+    .action(() => {
+      const cfg = readFederationConfig();
+      if (cfg.peers.length === 0) {
+        console.log('No static peers configured.');
+        return;
+      }
+      console.log('Static peers:');
+      for (const p of cfg.peers) {
+        console.log(`  - ${p}`);
+      }
+    });
+
+  return command;
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -17,3 +17,4 @@ export { createRunCommand } from './run.js';
 export { createAuditCommand } from './audit.js';
 export { createExportAgentsCommand } from './export-agents.js';
 export { createAgentPortableCommand } from './agent-portable.js';
+export { createFederationCommand } from './federation.js';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -21,6 +21,7 @@ import {
   createAuditCommand,
   createExportAgentsCommand,
   createAgentPortableCommand,
+  createFederationCommand,
 } from './commands/index.js';
 
 // Read version from package.json would be ideal, but for now hardcode
@@ -61,6 +62,7 @@ async function main(): Promise<void> {
   program.addCommand(createAuditCommand());
   program.addCommand(createExportAgentsCommand());
   program.addCommand(createAgentPortableCommand());
+  program.addCommand(createFederationCommand());
 
   // Parse arguments
   await program.parseAsync(process.argv);

--- a/src/federation/discovery.ts
+++ b/src/federation/discovery.ts
@@ -1,0 +1,359 @@
+/**
+ * Discovery layer for federation peers.
+ *
+ * Two strategies are provided out of the box:
+ *
+ *   - MdnsDiscovery       Bonjour / multicast DNS on the local network.
+ *                         Uses the optional `bonjour-service` package; when the
+ *                         package is not installed the discovery is a no-op and
+ *                         emits a warning. This keeps the dependency optional.
+ *   - RegistryDiscovery   Central HTTP registry that exposes a list of nodes.
+ *
+ * A simple 'static' discovery (just the configured peers list) is provided by
+ * `StaticDiscovery` and is used as bootstrap for the other strategies.
+ *
+ * All discoveries share the `Discovery` interface so they can be swapped at
+ * runtime without touching the routing / transport layers.
+ */
+
+import { logger } from '../utils/logger.js';
+import type {
+  DiscoveryMethod,
+  FederationConfig,
+  NodeInfo,
+} from './types.js';
+
+const log = logger.child('federation:discovery');
+
+const DEFAULT_MDNS_SERVICE_TYPE = '_aistack._tcp.local';
+
+/**
+ * Listener invoked when the set of known peers changes.
+ */
+export type PeerListener = (peers: NodeInfo[]) => void;
+
+/**
+ * Common shape for all discovery implementations.
+ */
+export interface Discovery {
+  /** Strategy name (matches FederationConfig.discoveryMethod). */
+  readonly method: DiscoveryMethod;
+  /** Start advertising (if `advertise` is true) and start watching for peers. */
+  start(self: NodeInfo, advertise: boolean): Promise<void>;
+  /** Stop discovery and release resources. */
+  stop(): Promise<void>;
+  /** Currently known peers (excluding `self`). */
+  peers(): NodeInfo[];
+  /** Subscribe to peer-set changes. Returns an unsubscribe handle. */
+  onChange(listener: PeerListener): () => void;
+}
+
+/**
+ * Internal helper - manages listener list + dedup.
+ */
+abstract class BaseDiscovery implements Discovery {
+  abstract readonly method: DiscoveryMethod;
+  protected knownPeers = new Map<string, NodeInfo>();
+  private listeners = new Set<PeerListener>();
+  protected selfId: string | null = null;
+
+  abstract start(self: NodeInfo, advertise: boolean): Promise<void>;
+  abstract stop(): Promise<void>;
+
+  peers(): NodeInfo[] {
+    return Array.from(this.knownPeers.values());
+  }
+
+  onChange(listener: PeerListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  protected upsertPeer(peer: NodeInfo): void {
+    if (this.selfId && peer.nodeId === this.selfId) {
+      return; // never include self
+    }
+    const existing = this.knownPeers.get(peer.nodeId);
+    const merged: NodeInfo = existing ? { ...existing, ...peer } : peer;
+    this.knownPeers.set(peer.nodeId, merged);
+    this.notify();
+  }
+
+  protected removePeer(nodeId: string): void {
+    if (this.knownPeers.delete(nodeId)) {
+      this.notify();
+    }
+  }
+
+  protected notify(): void {
+    const snapshot = this.peers();
+    for (const l of this.listeners) {
+      try {
+        l(snapshot);
+      } catch (err) {
+        log.warn('Peer listener threw', { error: err instanceof Error ? err.message : String(err) });
+      }
+    }
+  }
+}
+
+/**
+ * StaticDiscovery just exposes a fixed list of peers from configuration.
+ *
+ * Useful for tests, air-gapped deployments, and as a bootstrap for the other
+ * strategies (the static peers are merged in by the FederationManager).
+ */
+export class StaticDiscovery extends BaseDiscovery {
+  readonly method: DiscoveryMethod = 'static';
+  private readonly staticPeers: NodeInfo[];
+
+  constructor(staticPeers: NodeInfo[]) {
+    super();
+    this.staticPeers = staticPeers;
+  }
+
+  async start(self: NodeInfo): Promise<void> {
+    this.selfId = self.nodeId;
+    for (const p of this.staticPeers) {
+      this.upsertPeer(p);
+    }
+    log.info('Static discovery started', { peers: this.staticPeers.length });
+  }
+
+  async stop(): Promise<void> {
+    this.knownPeers.clear();
+  }
+}
+
+/**
+ * MdnsDiscovery uses Bonjour / multicast DNS on the local network.
+ *
+ * The `bonjour-service` package is loaded dynamically so that aistack works
+ * without it. If the package is missing, discovery degrades to a no-op and
+ * a warning is logged once.
+ */
+export class MdnsDiscovery extends BaseDiscovery {
+  readonly method: DiscoveryMethod = 'mdns';
+  private readonly serviceType: string;
+  private bonjour: unknown = null;
+  private service: unknown = null;
+  private browser: unknown = null;
+  private static warnedMissing = false;
+
+  constructor(serviceType: string = DEFAULT_MDNS_SERVICE_TYPE) {
+    super();
+    this.serviceType = serviceType;
+  }
+
+  async start(self: NodeInfo, advertise: boolean): Promise<void> {
+    this.selfId = self.nodeId;
+    const lib = await this.tryLoadBonjour();
+    if (!lib) return;
+
+    type BonjourCtor = new () => {
+      publish(opts: Record<string, unknown>): unknown;
+      find(opts: Record<string, unknown>, cb: (svc: Record<string, unknown>) => void): unknown;
+      destroy(): void;
+    };
+    const Ctor = lib as BonjourCtor;
+    const instance = new Ctor();
+    this.bonjour = instance;
+
+    if (advertise) {
+      // Parse host:port from self.address
+      const url = parseAddress(self.address);
+      this.service = instance.publish({
+        name: self.name,
+        type: this.serviceType.replace(/^_/, '').replace(/\._tcp\.local$/, ''),
+        port: url.port,
+        txt: {
+          nodeId: self.nodeId,
+          scheme: self.scheme,
+          capabilities: self.capabilities.map((c) => c.name).join(','),
+          version: self.version ?? '',
+        },
+      });
+      log.info('mDNS advertise started', { name: self.name, port: url.port });
+    }
+
+    this.browser = instance.find(
+      { type: this.serviceType.replace(/^_/, '').replace(/\._tcp\.local$/, '') },
+      (svc) => {
+        try {
+          const peer = bonjourServiceToNodeInfo(svc);
+          if (peer) this.upsertPeer(peer);
+        } catch (err) {
+          log.debug('mDNS service parse failed', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+    );
+  }
+
+  async stop(): Promise<void> {
+    try {
+      type Destroyable = { destroy?: () => void; stop?: () => void };
+      const svc = this.service as Destroyable | null;
+      const br = this.browser as Destroyable | null;
+      const bj = this.bonjour as Destroyable | null;
+      if (svc?.stop) svc.stop();
+      if (br?.stop) br.stop();
+      if (bj?.destroy) bj.destroy();
+    } catch (err) {
+      log.warn('mDNS stop error', { error: err instanceof Error ? err.message : String(err) });
+    }
+    this.knownPeers.clear();
+  }
+
+  private async tryLoadBonjour(): Promise<unknown> {
+    try {
+      const mod = (await import('bonjour-service' as string)) as Record<string, unknown>;
+      return (mod.Bonjour as unknown) ?? (mod.default as unknown);
+    } catch {
+      if (!MdnsDiscovery.warnedMissing) {
+        MdnsDiscovery.warnedMissing = true;
+        log.warn(
+          'bonjour-service package is not installed - mDNS discovery disabled. ' +
+            'Run `npm install bonjour-service` to enable LAN auto-discovery.'
+        );
+      }
+      return null;
+    }
+  }
+}
+
+/**
+ * RegistryDiscovery polls a central HTTP endpoint that returns a JSON array
+ * of NodeInfo entries.
+ *
+ * The expected wire shape is `{ nodes: NodeInfo[] }`. POST /register on the
+ * same base URL is used to advertise this node when `advertise` is true.
+ */
+export class RegistryDiscovery extends BaseDiscovery {
+  readonly method: DiscoveryMethod = 'registry';
+  private readonly registryUrl: string;
+  private pollHandle: ReturnType<typeof setInterval> | null = null;
+  private readonly pollIntervalMs: number;
+
+  constructor(registryUrl: string, pollIntervalMs: number = 15000) {
+    super();
+    this.registryUrl = registryUrl.replace(/\/$/, '');
+    this.pollIntervalMs = pollIntervalMs;
+  }
+
+  async start(self: NodeInfo, advertise: boolean): Promise<void> {
+    this.selfId = self.nodeId;
+
+    if (advertise) {
+      await this.register(self).catch((err) =>
+        log.warn('Registry register failed', { error: err instanceof Error ? err.message : String(err) })
+      );
+    }
+
+    await this.refresh();
+    this.pollHandle = setInterval(() => {
+      void this.refresh().catch(() => undefined);
+    }, this.pollIntervalMs);
+    // Don't keep the process alive solely for the registry poll.
+    if (this.pollHandle && typeof (this.pollHandle as unknown as { unref?: () => void }).unref === 'function') {
+      (this.pollHandle as unknown as { unref: () => void }).unref();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.pollHandle) {
+      clearInterval(this.pollHandle);
+      this.pollHandle = null;
+    }
+    this.knownPeers.clear();
+  }
+
+  private async register(self: NodeInfo): Promise<void> {
+    await fetch(`${this.registryUrl}/register`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(self),
+    });
+  }
+
+  private async refresh(): Promise<void> {
+    try {
+      const res = await fetch(`${this.registryUrl}/nodes`);
+      if (!res.ok) {
+        log.debug('Registry refresh non-ok', { status: res.status });
+        return;
+      }
+      const body = (await res.json()) as { nodes?: NodeInfo[] };
+      const incoming = body.nodes ?? [];
+      const incomingIds = new Set(incoming.map((p) => p.nodeId));
+      // Add / update
+      for (const p of incoming) this.upsertPeer(p);
+      // Remove gone peers
+      for (const id of Array.from(this.knownPeers.keys())) {
+        if (!incomingIds.has(id)) this.removePeer(id);
+      }
+    } catch (err) {
+      log.debug('Registry refresh failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+}
+
+/**
+ * Factory that returns a Discovery instance matching the configured method.
+ * The caller is responsible for calling `start` and `stop`.
+ */
+export function createDiscovery(
+  config: FederationConfig,
+  staticPeers: NodeInfo[]
+): Discovery {
+  switch (config.discoveryMethod) {
+    case 'mdns':
+      return new MdnsDiscovery(config.mdnsServiceType);
+    case 'registry':
+      if (!config.registryUrl) {
+        log.warn('registry discovery selected but no registryUrl - falling back to static');
+        return new StaticDiscovery(staticPeers);
+      }
+      return new RegistryDiscovery(config.registryUrl);
+    case 'static':
+    default:
+      return new StaticDiscovery(staticPeers);
+  }
+}
+
+/* ---------- helpers ---------- */
+
+function parseAddress(addr: string): { host: string; port: number } {
+  // Accept host:port, https://host:port, http://host:port
+  let s = addr.trim();
+  s = s.replace(/^https?:\/\//, '');
+  const [host, portStr] = s.split(':');
+  const port = Number.parseInt(portStr ?? '0', 10);
+  return { host: host || 'localhost', port: Number.isFinite(port) ? port : 0 };
+}
+
+function bonjourServiceToNodeInfo(svc: Record<string, unknown>): NodeInfo | null {
+  const txt = (svc.txt ?? {}) as Record<string, string>;
+  const nodeId = txt.nodeId;
+  if (!nodeId) return null;
+  const host = (svc.host as string) ?? (svc.referer as { address?: string } | undefined)?.address ?? 'localhost';
+  const port = (svc.port as number) ?? 0;
+  const scheme = (txt.scheme as 'https' | 'http') ?? 'https';
+  const capabilities = (txt.capabilities ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((name) => ({ name, enabled: true }));
+  return {
+    nodeId,
+    name: (svc.name as string) ?? nodeId,
+    address: `${scheme}://${host}:${port}`,
+    scheme,
+    capabilities: capabilities as NodeInfo['capabilities'],
+    version: txt.version || undefined,
+    lastSeen: new Date(),
+  };
+}

--- a/src/federation/discovery.ts
+++ b/src/federation/discovery.ts
@@ -12,14 +12,24 @@
  * A simple 'static' discovery (just the configured peers list) is provided by
  * `StaticDiscovery` and is used as bootstrap for the other strategies.
  *
+ * Beacon signing (AIG-652 review fix #4):
+ *   Discovery beacons are unauthenticated on the wire (mDNS especially is
+ *   trivially spoofable on a LAN). We layer Ed25519 signatures on top: each
+ *   beacon carries `sig` + `pub`, peers verify on receive, unsigned/unknown
+ *   beacons are dropped when the local node has a `trustedPublicKeys`
+ *   allowlist configured.
+ *
  * All discoveries share the `Discovery` interface so they can be swapped at
  * runtime without touching the routing / transport layers.
  */
 
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
 import { logger } from '../utils/logger.js';
 import type {
   DiscoveryMethod,
   FederationConfig,
+  FederationDiscoverySigningConfig,
   NodeInfo,
 } from './types.js';
 
@@ -31,6 +41,151 @@ const DEFAULT_MDNS_SERVICE_TYPE = '_aistack._tcp.local';
  * Listener invoked when the set of known peers changes.
  */
 export type PeerListener = (peers: NodeInfo[]) => void;
+
+/**
+ * Materialized signer state. `signer` is null when no private key is
+ * configured (we still verify incoming beacons against `trustedPublicKeys`).
+ */
+export interface BeaconSigner {
+  /** PEM-encoded Ed25519 public key (also embedded in outgoing beacons). */
+  publicKeyPem: string | null;
+  /** Private key wrapper used to sign outgoing beacons. */
+  sign: ((payload: string) => string) | null;
+  /** Allowlist of peer public keys (PEM, normalized). When empty, verification is best-effort. */
+  trustedPublicKeys: Set<string>;
+  /** True if at least one peer key is pinned (verification becomes mandatory). */
+  enforceTrust: boolean;
+}
+
+/**
+ * Build the BeaconSigner from FederationDiscoverySigningConfig.
+ * Throws on misconfiguration (e.g. unreadable key file).
+ */
+export function buildBeaconSigner(
+  cfg: FederationDiscoverySigningConfig | undefined
+): BeaconSigner {
+  const signer: BeaconSigner = {
+    publicKeyPem: null,
+    sign: null,
+    trustedPublicKeys: new Set(),
+    enforceTrust: false,
+  };
+
+  if (cfg?.publicKeyPath) {
+    try {
+      signer.publicKeyPem = normalizePem(fs.readFileSync(cfg.publicKeyPath, 'utf-8'));
+    } catch (err) {
+      throw new Error(
+        `Federation discovery publicKeyPath could not be read at "${cfg.publicKeyPath}": ` +
+          (err instanceof Error ? err.message : String(err))
+      );
+    }
+  }
+
+  if (cfg?.privateKeyPath) {
+    let pem: string;
+    try {
+      pem = fs.readFileSync(cfg.privateKeyPath, 'utf-8');
+    } catch (err) {
+      throw new Error(
+        `Federation discovery privateKeyPath could not be read at "${cfg.privateKeyPath}": ` +
+          (err instanceof Error ? err.message : String(err))
+      );
+    }
+    const keyObj = crypto.createPrivateKey({ key: pem, format: 'pem' });
+    if (keyObj.asymmetricKeyType !== 'ed25519') {
+      throw new Error(
+        `Federation discovery privateKey must be Ed25519 (got ${keyObj.asymmetricKeyType}).`
+      );
+    }
+    signer.sign = (payload: string): string => {
+      const sigBuf = crypto.sign(null, Buffer.from(payload, 'utf-8'), keyObj);
+      return sigBuf.toString('base64');
+    };
+  }
+
+  if (Array.isArray(cfg?.trustedPublicKeys)) {
+    for (const pem of cfg!.trustedPublicKeys!) {
+      signer.trustedPublicKeys.add(normalizePem(pem));
+    }
+    signer.enforceTrust = signer.trustedPublicKeys.size > 0;
+  }
+
+  if (!signer.sign && !signer.enforceTrust) {
+    log.warn(
+      'Federation discovery beacons are UNSIGNED. Configure ' +
+        'federation.discoverySigning to enable Ed25519 beacon signing.'
+    );
+  }
+
+  return signer;
+}
+
+/**
+ * Verify a beacon signature using the embedded `pub` key. Also enforces
+ * that the embedded key is in the local trust allowlist when one is set.
+ *
+ * Returns `true` when the beacon is acceptable, `false` otherwise.
+ */
+export function verifyBeacon(
+  signer: BeaconSigner,
+  payload: string,
+  signatureB64: string | undefined,
+  publicKeyPem: string | undefined
+): { ok: boolean; reason: string } {
+  if (!signatureB64 || !publicKeyPem) {
+    if (signer.enforceTrust) {
+      return { ok: false, reason: 'beacon is unsigned' };
+    }
+    // Best-effort mode: accept unsigned beacons but tag them.
+    return { ok: true, reason: 'unsigned (best-effort mode)' };
+  }
+  const pem = normalizePem(publicKeyPem);
+  if (signer.enforceTrust && !signer.trustedPublicKeys.has(pem)) {
+    return { ok: false, reason: 'beacon signer not in trustedPublicKeys' };
+  }
+  try {
+    const keyObj = crypto.createPublicKey({ key: pem, format: 'pem' });
+    if (keyObj.asymmetricKeyType !== 'ed25519') {
+      return { ok: false, reason: 'beacon public key is not Ed25519' };
+    }
+    const ok = crypto.verify(
+      null,
+      Buffer.from(payload, 'utf-8'),
+      keyObj,
+      Buffer.from(signatureB64, 'base64')
+    );
+    return ok ? { ok: true, reason: 'verified' } : { ok: false, reason: 'invalid signature' };
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `beacon verify error: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * Canonical JSON payload representing the signed portion of a beacon. We
+ * intentionally include nodeId, address, scheme, capabilities + a sequence
+ * number ("seq") so an attacker cannot replay an old capability list while
+ * the node changes its real capabilities.
+ */
+export function canonicalBeaconPayload(node: NodeInfo, seq: number): string {
+  // Stable key order; whitespace-free; capabilities reduced to names.
+  return JSON.stringify({
+    nodeId: node.nodeId,
+    name: node.name,
+    address: node.address,
+    scheme: node.scheme,
+    capabilities: (node.capabilities || []).map((c) => c.name).sort(),
+    version: node.version ?? '',
+    seq,
+  });
+}
+
+function normalizePem(pem: string): string {
+  return pem.replace(/\r\n/g, '\n').trim();
+}
 
 /**
  * Common shape for all discovery implementations.
@@ -56,6 +211,11 @@ abstract class BaseDiscovery implements Discovery {
   protected knownPeers = new Map<string, NodeInfo>();
   private listeners = new Set<PeerListener>();
   protected selfId: string | null = null;
+  protected signer: BeaconSigner;
+
+  constructor(signer: BeaconSigner) {
+    this.signer = signer;
+  }
 
   abstract start(self: NodeInfo, advertise: boolean): Promise<void>;
   abstract stop(): Promise<void>;
@@ -102,13 +262,16 @@ abstract class BaseDiscovery implements Discovery {
  *
  * Useful for tests, air-gapped deployments, and as a bootstrap for the other
  * strategies (the static peers are merged in by the FederationManager).
+ *
+ * Static peers are configured locally and are NOT subject to beacon
+ * verification (the operator already trusted them by hard-coding them).
  */
 export class StaticDiscovery extends BaseDiscovery {
   readonly method: DiscoveryMethod = 'static';
   private readonly staticPeers: NodeInfo[];
 
-  constructor(staticPeers: NodeInfo[]) {
-    super();
+  constructor(staticPeers: NodeInfo[], signer: BeaconSigner = noopSigner()) {
+    super(signer);
     this.staticPeers = staticPeers;
   }
 
@@ -131,6 +294,10 @@ export class StaticDiscovery extends BaseDiscovery {
  * The `bonjour-service` package is loaded dynamically so that aistack works
  * without it. If the package is missing, discovery degrades to a no-op and
  * a warning is logged once.
+ *
+ * Each advertised TXT record carries `sig` (base64 Ed25519 signature) and
+ * `pub` (base64-or-PEM Ed25519 public key). Incoming services without a
+ * valid signature are dropped when the local node enforces signing.
  */
 export class MdnsDiscovery extends BaseDiscovery {
   readonly method: DiscoveryMethod = 'mdns';
@@ -140,8 +307,8 @@ export class MdnsDiscovery extends BaseDiscovery {
   private browser: unknown = null;
   private static warnedMissing = false;
 
-  constructor(serviceType: string = DEFAULT_MDNS_SERVICE_TYPE) {
-    super();
+  constructor(serviceType: string = DEFAULT_MDNS_SERVICE_TYPE, signer: BeaconSigner = noopSigner()) {
+    super(signer);
     this.serviceType = serviceType;
   }
 
@@ -162,6 +329,12 @@ export class MdnsDiscovery extends BaseDiscovery {
     if (advertise) {
       // Parse host:port from self.address
       const url = parseAddress(self.address);
+      const seq = Date.now();
+      const payload = canonicalBeaconPayload(self, seq);
+      const sig = this.signer.sign ? this.signer.sign(payload) : '';
+      const pubB64 = this.signer.publicKeyPem
+        ? Buffer.from(this.signer.publicKeyPem, 'utf-8').toString('base64')
+        : '';
       this.service = instance.publish({
         name: self.name,
         type: this.serviceType.replace(/^_/, '').replace(/\._tcp\.local$/, ''),
@@ -171,9 +344,12 @@ export class MdnsDiscovery extends BaseDiscovery {
           scheme: self.scheme,
           capabilities: self.capabilities.map((c) => c.name).join(','),
           version: self.version ?? '',
+          seq: String(seq),
+          sig,
+          pub: pubB64,
         },
       });
-      log.info('mDNS advertise started', { name: self.name, port: url.port });
+      log.info('mDNS advertise started', { name: self.name, port: url.port, signed: !!sig });
     }
 
     this.browser = instance.find(
@@ -181,7 +357,23 @@ export class MdnsDiscovery extends BaseDiscovery {
       (svc) => {
         try {
           const peer = bonjourServiceToNodeInfo(svc);
-          if (peer) this.upsertPeer(peer);
+          if (!peer) return;
+          // Verify the beacon signature before accepting.
+          const txt = (svc.txt ?? {}) as Record<string, string>;
+          const seq = Number.parseInt(txt.seq ?? '0', 10);
+          const payload = canonicalBeaconPayload(peer, Number.isFinite(seq) ? seq : 0);
+          const pubPem = txt.pub
+            ? Buffer.from(txt.pub, 'base64').toString('utf-8')
+            : undefined;
+          const verdict = verifyBeacon(this.signer, payload, txt.sig, pubPem);
+          if (!verdict.ok) {
+            log.warn('Dropping mDNS beacon - signature check failed', {
+              peer: peer.nodeId,
+              reason: verdict.reason,
+            });
+            return;
+          }
+          this.upsertPeer(peer);
         } catch (err) {
           log.debug('mDNS service parse failed', {
             error: err instanceof Error ? err.message : String(err),
@@ -227,8 +419,12 @@ export class MdnsDiscovery extends BaseDiscovery {
  * RegistryDiscovery polls a central HTTP endpoint that returns a JSON array
  * of NodeInfo entries.
  *
- * The expected wire shape is `{ nodes: NodeInfo[] }`. POST /register on the
- * same base URL is used to advertise this node when `advertise` is true.
+ * Wire format (signed):
+ *   POST /register { node: NodeInfo, seq: number, sig: string, pub: string }
+ *   GET  /nodes    -> { nodes: [{ node, seq, sig, pub }] }
+ *
+ * Incoming entries are dropped if the signature does not verify (and the
+ * local node has a trustedPublicKeys allowlist).
  */
 export class RegistryDiscovery extends BaseDiscovery {
   readonly method: DiscoveryMethod = 'registry';
@@ -236,8 +432,8 @@ export class RegistryDiscovery extends BaseDiscovery {
   private pollHandle: ReturnType<typeof setInterval> | null = null;
   private readonly pollIntervalMs: number;
 
-  constructor(registryUrl: string, pollIntervalMs: number = 15000) {
-    super();
+  constructor(registryUrl: string, signer: BeaconSigner = noopSigner(), pollIntervalMs: number = 15000) {
+    super(signer);
     this.registryUrl = registryUrl.replace(/\/$/, '');
     this.pollIntervalMs = pollIntervalMs;
   }
@@ -270,10 +466,14 @@ export class RegistryDiscovery extends BaseDiscovery {
   }
 
   private async register(self: NodeInfo): Promise<void> {
+    const seq = Date.now();
+    const payload = canonicalBeaconPayload(self, seq);
+    const sig = this.signer.sign ? this.signer.sign(payload) : '';
+    const pub = this.signer.publicKeyPem ?? '';
     await fetch(`${this.registryUrl}/register`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(self),
+      body: JSON.stringify({ node: self, seq, sig, pub }),
     });
   }
 
@@ -284,14 +484,36 @@ export class RegistryDiscovery extends BaseDiscovery {
         log.debug('Registry refresh non-ok', { status: res.status });
         return;
       }
-      const body = (await res.json()) as { nodes?: NodeInfo[] };
+      const body = (await res.json()) as {
+        nodes?: Array<
+          | NodeInfo
+          | { node: NodeInfo; seq?: number; sig?: string; pub?: string }
+        >;
+      };
       const incoming = body.nodes ?? [];
-      const incomingIds = new Set(incoming.map((p) => p.nodeId));
-      // Add / update
-      for (const p of incoming) this.upsertPeer(p);
+      const validIds = new Set<string>();
+      for (const entry of incoming) {
+        // Accept both legacy (bare NodeInfo) and signed envelope shapes.
+        const isEnvelope = (entry as { node?: NodeInfo }).node !== undefined;
+        const node = isEnvelope ? (entry as { node: NodeInfo }).node : (entry as NodeInfo);
+        const sig = isEnvelope ? (entry as { sig?: string }).sig : undefined;
+        const pub = isEnvelope ? (entry as { pub?: string }).pub : undefined;
+        const seq = isEnvelope ? (entry as { seq?: number }).seq ?? 0 : 0;
+        const payload = canonicalBeaconPayload(node, seq);
+        const verdict = verifyBeacon(this.signer, payload, sig, pub);
+        if (!verdict.ok) {
+          log.warn('Dropping registry entry - signature check failed', {
+            peer: node.nodeId,
+            reason: verdict.reason,
+          });
+          continue;
+        }
+        validIds.add(node.nodeId);
+        this.upsertPeer(node);
+      }
       // Remove gone peers
       for (const id of Array.from(this.knownPeers.keys())) {
-        if (!incomingIds.has(id)) this.removePeer(id);
+        if (!validIds.has(id)) this.removePeer(id);
       }
     } catch (err) {
       log.debug('Registry refresh failed', {
@@ -307,21 +529,32 @@ export class RegistryDiscovery extends BaseDiscovery {
  */
 export function createDiscovery(
   config: FederationConfig,
-  staticPeers: NodeInfo[]
+  staticPeers: NodeInfo[],
+  signer: BeaconSigner = noopSigner()
 ): Discovery {
   switch (config.discoveryMethod) {
     case 'mdns':
-      return new MdnsDiscovery(config.mdnsServiceType);
+      return new MdnsDiscovery(config.mdnsServiceType, signer);
     case 'registry':
       if (!config.registryUrl) {
         log.warn('registry discovery selected but no registryUrl - falling back to static');
-        return new StaticDiscovery(staticPeers);
+        return new StaticDiscovery(staticPeers, signer);
       }
-      return new RegistryDiscovery(config.registryUrl);
+      return new RegistryDiscovery(config.registryUrl, signer);
     case 'static':
     default:
-      return new StaticDiscovery(staticPeers);
+      return new StaticDiscovery(staticPeers, signer);
   }
+}
+
+/** Signer that performs no signing and accepts unsigned beacons (legacy). */
+export function noopSigner(): BeaconSigner {
+  return {
+    publicKeyPem: null,
+    sign: null,
+    trustedPublicKeys: new Set(),
+    enforceTrust: false,
+  };
 }
 
 /* ---------- helpers ---------- */

--- a/src/federation/index.ts
+++ b/src/federation/index.ts
@@ -1,0 +1,274 @@
+/**
+ * Federation module - public surface.
+ *
+ * The `FederationManager` wires together discovery + routing + transport +
+ * server and exposes a small high-level API:
+ *
+ *   const fed = createFederation(config);
+ *   await fed.join();
+ *   const decision = fed.delegateTask({ taskId, agentType, input });
+ *   if (decision.peer) await fed.submitTask(decision.peer, task);
+ *   await fed.leave();
+ *
+ * The manager is opt-in: nothing else in aistack imports it directly.
+ * Coordinators can call `delegateTask` only when they want to spread work.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { logger } from '../utils/logger.js';
+import { createDiscovery, Discovery } from './discovery.js';
+import { TaskRouter } from './routing.js';
+import {
+  FederationClient,
+  FederationCredentials,
+  loadCredentials,
+} from './transport.js';
+import { FederationServer, type TaskHandler } from './server.js';
+import type {
+  Capability,
+  FederationConfig,
+  FederationStatus,
+  NodeInfo,
+  RoutingDecision,
+  RoutingPolicy,
+  TaskDelegation,
+  TaskDelegationResult,
+} from './types.js';
+
+export * from './types.js';
+export { TaskRouter } from './routing.js';
+export {
+  loadCredentials,
+  buildHttpsAgent,
+  verifyPeerRequest,
+  sanitizeDelegation,
+  FederationClient,
+} from './transport.js';
+export {
+  StaticDiscovery,
+  MdnsDiscovery,
+  RegistryDiscovery,
+  createDiscovery,
+} from './discovery.js';
+export { FederationServer } from './server.js';
+
+const log = logger.child('federation');
+
+/**
+ * Federation default config shared with the Zod schema in utils/config.ts.
+ */
+export const FEDERATION_DEFAULTS: FederationConfig = {
+  enabled: false,
+  discoveryMethod: 'static',
+  advertise: false,
+  peers: [],
+  bindAddress: '0.0.0.0',
+  bindPort: 0,
+  routingPolicy: 'least-loaded',
+  maxInputLength: 4096,
+  requestTimeoutMs: 10_000,
+  mdnsServiceType: '_aistack._tcp.local',
+};
+
+/**
+ * High-level federation orchestrator.
+ *
+ * The manager is intentionally stateless w.r.t. running tasks: when a peer
+ * accepts a delegated task, the local coordinator is the one waiting on the
+ * `submitTask` promise.
+ */
+export class FederationManager {
+  private readonly config: Required<Pick<FederationConfig, 'discoveryMethod' | 'advertise' | 'peers' | 'routingPolicy' | 'maxInputLength'>> &
+    FederationConfig;
+  private readonly credentials: FederationCredentials;
+  private readonly client: FederationClient;
+  private readonly router: TaskRouter;
+  private discovery: Discovery | null = null;
+  private server: FederationServer | null = null;
+  private selfInfo: NodeInfo;
+  private joinedAt?: Date;
+  private localCapabilities: Capability[] = [];
+  private taskHandler: TaskHandler | null = null;
+
+  constructor(config: FederationConfig) {
+    this.config = { ...FEDERATION_DEFAULTS, ...config };
+    this.credentials = loadCredentials(this.config.tls);
+    this.client = new FederationClient(this.credentials, {
+      maxInputLength: this.config.maxInputLength,
+      timeoutMs: this.config.requestTimeoutMs,
+    });
+    this.router = new TaskRouter();
+
+    const nodeId = this.config.nodeId ?? randomUUID();
+    const name = this.config.name ?? `aistack-${nodeId.slice(0, 8)}`;
+    const scheme: 'https' | 'http' =
+      this.credentials.cert && this.credentials.key ? 'https' : 'http';
+    const host = this.config.bindAddress ?? '0.0.0.0';
+    const port = this.config.bindPort ?? 0;
+    this.selfInfo = {
+      nodeId,
+      name,
+      address: `${scheme}://${host}:${port}`,
+      scheme,
+      capabilities: [],
+    };
+  }
+
+  /**
+   * Register the local capabilities advertised to peers. Should be called
+   * after spawner / registry are initialized.
+   */
+  setLocalCapabilities(caps: Capability[]): void {
+    this.localCapabilities = caps;
+    this.selfInfo = { ...this.selfInfo, capabilities: caps };
+  }
+
+  /**
+   * Register the local task handler invoked when a peer submits work.
+   * If not registered, incoming tasks are rejected with status `rejected`.
+   */
+  setTaskHandler(handler: TaskHandler): void {
+    this.taskHandler = handler;
+  }
+
+  /**
+   * Join the federation cluster: start the server, then start discovery.
+   * Safe to call when `config.enabled === false` — it becomes a no-op.
+   */
+  async join(): Promise<void> {
+    if (!this.config.enabled) {
+      log.info('Federation disabled - join is a no-op');
+      return;
+    }
+
+    // Start server first so we have a real port before advertising.
+    this.server = new FederationServer({
+      credentials: this.credentials,
+      selfInfo: () => this.selfInfo,
+      onTask: async (task) => this.dispatchIncomingTask(task),
+      bindAddress: this.config.bindAddress,
+      bindPort: this.config.bindPort,
+    });
+    await this.server.start();
+    const bound = this.server.getBoundAddress();
+    if (bound) {
+      this.selfInfo = {
+        ...this.selfInfo,
+        address: `${this.selfInfo.scheme}://${bound.host}:${bound.port}`,
+      };
+    }
+
+    // Discovery
+    const staticPeers = parseStaticPeers(this.config.peers);
+    this.discovery = createDiscovery(this.config, staticPeers);
+    await this.discovery.start(this.selfInfo, this.config.advertise);
+
+    this.joinedAt = new Date();
+    log.info('Federation joined', {
+      nodeId: this.selfInfo.nodeId,
+      method: this.config.discoveryMethod,
+      advertise: this.config.advertise,
+    });
+  }
+
+  /** Leave the federation: stop discovery, stop server. */
+  async leave(): Promise<void> {
+    if (this.discovery) {
+      await this.discovery.stop();
+      this.discovery = null;
+    }
+    if (this.server) {
+      await this.server.stop();
+      this.server = null;
+    }
+    this.joinedAt = undefined;
+    log.info('Federation left');
+  }
+
+  /** Snapshot of current federation state. */
+  status(): FederationStatus {
+    return {
+      enabled: this.config.enabled,
+      nodeId: this.selfInfo.nodeId,
+      name: this.selfInfo.name,
+      address: this.selfInfo.address,
+      peers: this.discovery?.peers() ?? [],
+      discoveryMethod: this.config.discoveryMethod,
+      joinedAt: this.joinedAt,
+    };
+  }
+
+  /** Currently known peers (empty when not joined). */
+  peers(): NodeInfo[] {
+    return this.discovery?.peers() ?? [];
+  }
+
+  /**
+   * Pick a peer for the given task. Returns a RoutingDecision with
+   * `peer === null` when no peer is suitable (caller should run locally).
+   *
+   * This is the opt-in hook that coordinators call - no other module
+   * is forced to import federation.
+   */
+  delegateTask(
+    task: TaskDelegation,
+    policy?: RoutingPolicy
+  ): RoutingDecision {
+    if (!this.config.enabled) {
+      return { peer: null, policy: this.config.routingPolicy, reason: 'federation disabled' };
+    }
+    return this.router.delegateTask(task, this.peers(), policy ?? this.config.routingPolicy);
+  }
+
+  /** Send a task to a peer and await the result. */
+  async submitTask(peer: NodeInfo, task: TaskDelegation): Promise<TaskDelegationResult> {
+    return this.client.submitTask(peer, task);
+  }
+
+  /** Fetch (and refresh) a peer's capabilities. */
+  async fetchPeerCapabilities(peer: NodeInfo): Promise<NodeInfo | null> {
+    return this.client.fetchPeerCapabilities(peer);
+  }
+
+  /**
+   * Called by the server when a peer submits a task. If no local handler is
+   * registered, the task is politely rejected.
+   */
+  private async dispatchIncomingTask(task: TaskDelegation): Promise<TaskDelegationResult> {
+    if (!this.taskHandler) {
+      return {
+        taskId: task.taskId,
+        status: 'rejected',
+        error: 'No local task handler registered',
+        executedBy: this.selfInfo.nodeId,
+      };
+    }
+    const result = await this.taskHandler(task);
+    return { ...result, executedBy: this.selfInfo.nodeId };
+  }
+}
+
+/**
+ * Factory: build a `FederationManager` from a sibling config block.
+ * Caller is responsible for `join()` / `leave()` lifecycle.
+ */
+export function createFederation(config: FederationConfig): FederationManager {
+  return new FederationManager(config);
+}
+
+/* ---------- helpers ---------- */
+
+function parseStaticPeers(peers: string[]): NodeInfo[] {
+  return peers.map((p, idx): NodeInfo => {
+    const url = p.includes('://') ? p : `https://${p}`;
+    const scheme: 'https' | 'http' = url.startsWith('https://') ? 'https' : 'http';
+    return {
+      nodeId: `static-${idx}`,
+      name: `static-${idx}`,
+      address: url,
+      scheme,
+      capabilities: [],
+    };
+  });
+}
+

--- a/src/federation/index.ts
+++ b/src/federation/index.ts
@@ -16,7 +16,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { logger } from '../utils/logger.js';
-import { createDiscovery, Discovery } from './discovery.js';
+import { buildBeaconSigner, BeaconSigner, createDiscovery, Discovery } from './discovery.js';
 import { TaskRouter } from './routing.js';
 import {
   FederationClient,
@@ -42,6 +42,9 @@ export {
   buildHttpsAgent,
   verifyPeerRequest,
   sanitizeDelegation,
+  timingSafeEqualString,
+  extractPeerCertNames,
+  MAX_BODY_BYTES,
   FederationClient,
 } from './transport.js';
 export {
@@ -49,8 +52,11 @@ export {
   MdnsDiscovery,
   RegistryDiscovery,
   createDiscovery,
+  buildBeaconSigner,
+  verifyBeacon,
+  canonicalBeaconPayload,
 } from './discovery.js';
-export { FederationServer } from './server.js';
+export { FederationServer, readJson } from './server.js';
 
 const log = logger.child('federation');
 
@@ -83,6 +89,7 @@ export class FederationManager {
   private readonly credentials: FederationCredentials;
   private readonly client: FederationClient;
   private readonly router: TaskRouter;
+  private readonly signer: BeaconSigner;
   private discovery: Discovery | null = null;
   private server: FederationServer | null = null;
   private selfInfo: NodeInfo;
@@ -92,7 +99,25 @@ export class FederationManager {
 
   constructor(config: FederationConfig) {
     this.config = { ...FEDERATION_DEFAULTS, ...config };
-    this.credentials = loadCredentials(this.config.tls);
+    // When federation is disabled the manager is a no-op; we MUST NOT enforce
+    // the strict credential gates (otherwise `aistack federation status` on
+    // a config without any TLS knobs would throw). The strict checks fire
+    // the moment the operator flips `enabled = true`.
+    if (this.config.enabled) {
+      this.credentials = loadCredentials(this.config.tls);
+      this.signer = buildBeaconSigner(this.config.discoverySigning);
+    } else {
+      this.credentials = {
+        cert: null,
+        key: null,
+        ca: null,
+        bearerToken: null,
+        requireClientCert: true,
+        trustedPeerCNs: [],
+        allowPlainText: true,
+      };
+      this.signer = buildBeaconSigner(undefined);
+    }
     this.client = new FederationClient(this.credentials, {
       maxInputLength: this.config.maxInputLength,
       timeoutMs: this.config.requestTimeoutMs,
@@ -160,7 +185,7 @@ export class FederationManager {
 
     // Discovery
     const staticPeers = parseStaticPeers(this.config.peers);
-    this.discovery = createDiscovery(this.config, staticPeers);
+    this.discovery = createDiscovery(this.config, staticPeers, this.signer);
     await this.discovery.start(this.selfInfo, this.config.advertise);
 
     this.joinedAt = new Date();

--- a/src/federation/routing.ts
+++ b/src/federation/routing.ts
@@ -1,0 +1,150 @@
+/**
+ * Routing layer - pick a remote peer for a task delegation.
+ *
+ * Three policies are supported:
+ *
+ *   - round-robin       Cycles peers that advertise the requested capability.
+ *   - least-loaded      Picks the peer with the lowest reported load (0..1).
+ *                       Ties broken by round-robin among the tied peers.
+ *   - capability-match  Picks the peer whose capability metadata + tags best
+ *                       match the task hints (preferredTags + agentType).
+ *
+ * The router is intentionally stateless aside from the round-robin cursor:
+ * peers and load come in as arguments, so this module is trivially testable.
+ */
+
+import { logger } from '../utils/logger.js';
+import type {
+  NodeInfo,
+  RoutingDecision,
+  RoutingPolicy,
+  TaskDelegation,
+} from './types.js';
+
+const log = logger.child('federation:routing');
+
+/**
+ * Per-router round-robin state.
+ */
+export class TaskRouter {
+  private rrCursor = 0;
+
+  /**
+   * Choose a peer for the given task. Returns a RoutingDecision with
+   * `peer === null` when no peer is suitable (caller should run locally).
+   */
+  delegateTask(
+    task: TaskDelegation,
+    peers: NodeInfo[],
+    policy: RoutingPolicy = 'least-loaded'
+  ): RoutingDecision {
+    const candidates = filterByCapability(task, peers);
+    if (candidates.length === 0) {
+      return {
+        peer: null,
+        policy,
+        reason: `No peer advertises capability "${task.agentType}"`,
+      };
+    }
+
+    let chosen: NodeInfo;
+    switch (policy) {
+      case 'round-robin':
+        chosen = this.pickRoundRobin(candidates);
+        break;
+      case 'capability-match':
+        chosen = pickCapabilityMatch(task, candidates);
+        break;
+      case 'least-loaded':
+      default:
+        chosen = this.pickLeastLoaded(candidates);
+        break;
+    }
+
+    log.debug('Delegation decision', {
+      taskId: task.taskId,
+      policy,
+      chosen: chosen.nodeId,
+      candidates: candidates.length,
+    });
+
+    return {
+      peer: chosen,
+      policy,
+      reason: `Selected via ${policy} from ${candidates.length} candidate(s)`,
+    };
+  }
+
+  private pickRoundRobin(peers: NodeInfo[]): NodeInfo {
+    const idx = this.rrCursor % peers.length;
+    this.rrCursor = (this.rrCursor + 1) % Math.max(peers.length, 1);
+    return peers[idx];
+  }
+
+  private pickLeastLoaded(peers: NodeInfo[]): NodeInfo {
+    let bestLoad = Number.POSITIVE_INFINITY;
+    const tied: NodeInfo[] = [];
+    for (const p of peers) {
+      const l = p.load ?? 0;
+      if (l < bestLoad) {
+        bestLoad = l;
+        tied.length = 0;
+        tied.push(p);
+      } else if (l === bestLoad) {
+        tied.push(p);
+      }
+    }
+    if (tied.length === 1) return tied[0];
+    // Break ties via round-robin among the tied set
+    return this.pickRoundRobin(tied);
+  }
+}
+
+/* ---------- helpers ---------- */
+
+/**
+ * Keep only peers that advertise the requested capability. The capability
+ * matches if the peer has any Capability entry with the same `name`. If the
+ * task carries explicit `requiredCapabilities`, all of them must be present.
+ */
+function filterByCapability(task: TaskDelegation, peers: NodeInfo[]): NodeInfo[] {
+  const required = new Set<string>([task.agentType, ...(task.hints?.requiredCapabilities ?? [])]);
+  return peers.filter((p) => {
+    const names = new Set(p.capabilities.map((c) => c.name));
+    for (const r of required) {
+      if (!names.has(r)) return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Capability-match score: +2 per preferred tag matched, +1 per metadata key
+ * match, plus a small bonus for lower load to break ties.
+ */
+function pickCapabilityMatch(task: TaskDelegation, peers: NodeInfo[]): NodeInfo {
+  const preferred = new Set(task.hints?.preferredTags ?? []);
+  let bestScore = -Infinity;
+  let best = peers[0];
+
+  for (const p of peers) {
+    let score = 0;
+    const tags = new Set(p.tags ?? []);
+    for (const t of preferred) if (tags.has(t)) score += 2;
+
+    const cap = p.capabilities.find((c) => c.name === task.agentType);
+    if (cap?.metadata && task.hints) {
+      for (const key of Object.keys(task.hints)) {
+        if (key in cap.metadata) score += 1;
+      }
+    }
+    // Tie-break: lower load wins
+    score += (1 - (p.load ?? 0)) * 0.1;
+
+    if (score > bestScore) {
+      bestScore = score;
+      best = p;
+    }
+  }
+  return best;
+}

--- a/src/federation/server.ts
+++ b/src/federation/server.ts
@@ -12,11 +12,21 @@
  * The server is intentionally minimal: no router framework, no JSON-Schema,
  * no middleware chain. Federation is a low-volume control-plane interface,
  * not a user-facing API. Lower complexity = smaller attack surface.
+ *
+ * Security posture:
+ *   - HTTPS w/ mTLS is the default. If cert/key are configured but missing
+ *     on disk, `loadCredentials` throws on startup (no silent downgrade).
+ *   - Plaintext HTTP is allowed ONLY when `tls.allowPlainText === true`.
+ *     That gate is also enforced here so the server cannot bind plain HTTP
+ *     by accident.
+ *   - Incoming bodies are capped at 1 MiB to bound denial-of-service.
+ *   - Peer cert CN/SAN pinning is enforced by `verifyPeerRequest`.
  */
 
 import * as http from 'node:http';
 import * as https from 'node:https';
 import type { AddressInfo } from 'node:net';
+import type { TLSSocket } from 'node:tls';
 import { logger } from '../utils/logger.js';
 import type {
   NodeInfo,
@@ -25,7 +35,9 @@ import type {
 } from './types.js';
 import {
   FederationCredentials,
+  MAX_BODY_BYTES,
   verifyPeerRequest,
+  type PeerCertificateLike,
 } from './transport.js';
 
 const log = logger.child('federation:server');
@@ -59,12 +71,23 @@ export class FederationServer {
   }
 
   /**
-   * Start the server. Uses HTTPS when a server cert+key are configured,
-   * otherwise falls back to HTTP (development only — a warning is logged).
+   * Start the server. Uses HTTPS when a server cert+key are configured.
+   *
+   * If TLS material is NOT configured AND `credentials.allowPlainText` is
+   * false, this method throws — we never silently bind a plain HTTP socket
+   * for federation traffic.
    */
   async start(): Promise<void> {
     const { credentials } = this.opts;
     const useHttps = !!(credentials.cert && credentials.key);
+
+    if (!useHttps && !credentials.allowPlainText) {
+      throw new Error(
+        'FederationServer refuses to start in plaintext HTTP mode. ' +
+          'Configure federation.tls.certPath + tls.keyPath, or explicitly set ' +
+          'federation.tls.allowPlainText = true for local development.'
+      );
+    }
 
     const handler = (req: http.IncomingMessage, res: http.ServerResponse): void => {
       this.handleRequest(req, res).catch((err) => {
@@ -92,7 +115,7 @@ export class FederationServer {
         handler
       );
     } else {
-      log.warn('Federation server starting in HTTP mode (no TLS material). Use only for dev/test.');
+      log.warn('Federation server starting in HTTP mode (allowPlainText=true). Use only for dev/test.');
       this.server = http.createServer(handler);
     }
 
@@ -133,11 +156,25 @@ export class FederationServer {
     req: http.IncomingMessage,
     res: http.ServerResponse
   ): Promise<void> {
-    // Authn / Authz
-    const tlsReq = req as http.IncomingMessage & {
-      socket: { getPeerCertificate?: () => { subject?: { CN?: string } } };
-    };
-    const peerCert = tlsReq.socket.getPeerCertificate ? tlsReq.socket.getPeerCertificate() : undefined;
+    // Extract peer certificate when this is a TLS connection. We probe the
+    // socket via `instanceof`-equivalent shape detection so the server still
+    // works in plain-HTTP dev mode (where there is no peer cert at all).
+    const sock = req.socket as Partial<TLSSocket>;
+    let peerCert: PeerCertificateLike | undefined;
+    if (typeof sock.getPeerCertificate === 'function') {
+      try {
+        const raw = sock.getPeerCertificate(true);
+        // getPeerCertificate returns {} when no cert is presented.
+        if (raw && (raw.subject || (raw as { subjectaltname?: string }).subjectaltname)) {
+          peerCert = raw as unknown as PeerCertificateLike;
+        }
+      } catch (err) {
+        log.debug('getPeerCertificate failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+
     const auth = verifyPeerRequest(this.opts.credentials, peerCert, req.headers.authorization);
     if (!auth.ok) {
       res.statusCode = 401;
@@ -158,7 +195,14 @@ export class FederationServer {
     }
 
     if (method === 'POST' && url.startsWith('/v1/federation/task')) {
-      const body = await readJson<TaskDelegation>(req);
+      const parsed = await readJson<TaskDelegation>(req);
+      if (parsed.tooLarge) {
+        res.statusCode = 413;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ error: 'payload_too_large', limitBytes: MAX_BODY_BYTES }));
+        return;
+      }
+      const body = parsed.value;
       if (!body || typeof body.taskId !== 'string' || typeof body.agentType !== 'string') {
         res.statusCode = 400;
         res.setHeader('content-type', 'application/json');
@@ -190,22 +234,61 @@ export class FederationServer {
 
 /* ---------- helpers ---------- */
 
-async function readJson<T>(req: http.IncomingMessage): Promise<T | null> {
-  return new Promise<T | null>((resolve) => {
+interface ReadJsonResult<T> {
+  value: T | null;
+  tooLarge: boolean;
+}
+
+/**
+ * Read and parse a JSON body with a hard size cap.
+ *
+ * The cap bounds simple denial-of-service from peers (or attackers who
+ * compromise the perimeter and probe the federation port).
+ */
+export async function readJson<T>(
+  req: http.IncomingMessage,
+  maxBytes: number = MAX_BODY_BYTES
+): Promise<ReadJsonResult<T>> {
+  return new Promise<ReadJsonResult<T>>((resolve) => {
     const chunks: Buffer[] = [];
-    req.on('data', (c: Buffer) => chunks.push(c));
+    let total = 0;
+    let tooLarge = false;
+    let settled = false;
+
+    const finish = (result: ReadJsonResult<T>): void => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+
+    req.on('data', (c: Buffer) => {
+      if (tooLarge) return;
+      total += c.length;
+      if (total > maxBytes) {
+        tooLarge = true;
+        // Stop draining; destroy with an error so upstream knows.
+        req.destroy(new Error('Federation request body exceeds cap'));
+        finish({ value: null, tooLarge: true });
+        return;
+      }
+      chunks.push(c);
+    });
     req.on('end', () => {
+      if (tooLarge) {
+        finish({ value: null, tooLarge: true });
+        return;
+      }
       if (chunks.length === 0) {
-        resolve(null);
+        finish({ value: null, tooLarge: false });
         return;
       }
       try {
         const raw = Buffer.concat(chunks).toString('utf-8');
-        resolve(JSON.parse(raw) as T);
+        finish({ value: JSON.parse(raw) as T, tooLarge: false });
       } catch {
-        resolve(null);
+        finish({ value: null, tooLarge: false });
       }
     });
-    req.on('error', () => resolve(null));
+    req.on('error', () => finish({ value: null, tooLarge }));
   });
 }

--- a/src/federation/server.ts
+++ b/src/federation/server.ts
@@ -1,0 +1,211 @@
+/**
+ * Federation HTTP(S) server.
+ *
+ * Exposes two endpoints over an isolated port (separate from the WebServer
+ * of AIG-636 so that public web traffic and peer-to-peer traffic can be
+ * firewalled independently):
+ *
+ *   GET  /v1/federation/capabilities  -> returns this node's NodeInfo
+ *   POST /v1/federation/task          -> accepts a TaskDelegation, executes
+ *                                        locally, returns TaskDelegationResult
+ *
+ * The server is intentionally minimal: no router framework, no JSON-Schema,
+ * no middleware chain. Federation is a low-volume control-plane interface,
+ * not a user-facing API. Lower complexity = smaller attack surface.
+ */
+
+import * as http from 'node:http';
+import * as https from 'node:https';
+import type { AddressInfo } from 'node:net';
+import { logger } from '../utils/logger.js';
+import type {
+  NodeInfo,
+  TaskDelegation,
+  TaskDelegationResult,
+} from './types.js';
+import {
+  FederationCredentials,
+  verifyPeerRequest,
+} from './transport.js';
+
+const log = logger.child('federation:server');
+
+/**
+ * Handler invoked when a peer submits a task. Implementations should
+ * delegate to the local coordinator. The handler is provided by the caller
+ * (FederationManager) to avoid coupling this module to the coordination
+ * package.
+ */
+export type TaskHandler = (task: TaskDelegation) => Promise<TaskDelegationResult>;
+
+export interface FederationServerOptions {
+  credentials: FederationCredentials;
+  selfInfo: () => NodeInfo;
+  onTask: TaskHandler;
+  bindAddress?: string;
+  bindPort?: number;
+}
+
+/**
+ * Lightweight federation HTTP(S) server.
+ */
+export class FederationServer {
+  private server: http.Server | https.Server | null = null;
+  private opts: FederationServerOptions;
+  private boundAddress: { host: string; port: number } | null = null;
+
+  constructor(opts: FederationServerOptions) {
+    this.opts = opts;
+  }
+
+  /**
+   * Start the server. Uses HTTPS when a server cert+key are configured,
+   * otherwise falls back to HTTP (development only — a warning is logged).
+   */
+  async start(): Promise<void> {
+    const { credentials } = this.opts;
+    const useHttps = !!(credentials.cert && credentials.key);
+
+    const handler = (req: http.IncomingMessage, res: http.ServerResponse): void => {
+      this.handleRequest(req, res).catch((err) => {
+        log.warn('Federation request handler crashed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        try {
+          res.statusCode = 500;
+          res.end();
+        } catch {
+          /* ignore */
+        }
+      });
+    };
+
+    if (useHttps) {
+      this.server = https.createServer(
+        {
+          cert: credentials.cert ?? undefined,
+          key: credentials.key ?? undefined,
+          ca: credentials.ca ?? undefined,
+          requestCert: credentials.requireClientCert,
+          rejectUnauthorized: credentials.requireClientCert && !!credentials.ca,
+        },
+        handler
+      );
+    } else {
+      log.warn('Federation server starting in HTTP mode (no TLS material). Use only for dev/test.');
+      this.server = http.createServer(handler);
+    }
+
+    await new Promise<void>((resolve) => {
+      this.server!.listen(
+        this.opts.bindPort ?? 0,
+        this.opts.bindAddress ?? '0.0.0.0',
+        () => resolve()
+      );
+    });
+
+    const addr = this.server.address() as AddressInfo | null;
+    this.boundAddress = addr
+      ? { host: addr.address, port: addr.port }
+      : { host: this.opts.bindAddress ?? '0.0.0.0', port: this.opts.bindPort ?? 0 };
+
+    log.info('Federation server listening', {
+      address: this.boundAddress,
+      scheme: useHttps ? 'https' : 'http',
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.server) return;
+    await new Promise<void>((resolve) => {
+      this.server!.close(() => resolve());
+    });
+    this.server = null;
+    this.boundAddress = null;
+  }
+
+  /** Returns the bound `{host, port}` (after `start`). */
+  getBoundAddress(): { host: string; port: number } | null {
+    return this.boundAddress;
+  }
+
+  private async handleRequest(
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> {
+    // Authn / Authz
+    const tlsReq = req as http.IncomingMessage & {
+      socket: { getPeerCertificate?: () => { subject?: { CN?: string } } };
+    };
+    const peerCert = tlsReq.socket.getPeerCertificate ? tlsReq.socket.getPeerCertificate() : undefined;
+    const auth = verifyPeerRequest(this.opts.credentials, peerCert, req.headers.authorization);
+    if (!auth.ok) {
+      res.statusCode = 401;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ error: 'unauthorized', reason: auth.reason }));
+      return;
+    }
+
+    const url = req.url ?? '';
+    const method = req.method ?? 'GET';
+
+    if (method === 'GET' && url.startsWith('/v1/federation/capabilities')) {
+      const self = this.opts.selfInfo();
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(self));
+      return;
+    }
+
+    if (method === 'POST' && url.startsWith('/v1/federation/task')) {
+      const body = await readJson<TaskDelegation>(req);
+      if (!body || typeof body.taskId !== 'string' || typeof body.agentType !== 'string') {
+        res.statusCode = 400;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ error: 'invalid_payload' }));
+        return;
+      }
+      try {
+        const result = await this.opts.onTask(body);
+        res.statusCode = 200;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(result));
+      } catch (err) {
+        res.statusCode = 500;
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            error: 'task_failed',
+            message: err instanceof Error ? err.message : String(err),
+          })
+        );
+      }
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end();
+  }
+}
+
+/* ---------- helpers ---------- */
+
+async function readJson<T>(req: http.IncomingMessage): Promise<T | null> {
+  return new Promise<T | null>((resolve) => {
+    const chunks: Buffer[] = [];
+    req.on('data', (c: Buffer) => chunks.push(c));
+    req.on('end', () => {
+      if (chunks.length === 0) {
+        resolve(null);
+        return;
+      }
+      try {
+        const raw = Buffer.concat(chunks).toString('utf-8');
+        resolve(JSON.parse(raw) as T);
+      } catch {
+        resolve(null);
+      }
+    });
+    req.on('error', () => resolve(null));
+  });
+}

--- a/src/federation/transport.ts
+++ b/src/federation/transport.ts
@@ -4,12 +4,16 @@
  *
  * Default security posture is mutual TLS (mTLS):
  *   - The local node loads cert / key / CA from disk via `loadCredentials`.
- *   - Outgoing requests use an https.Agent built from those credentials.
- *   - Incoming requests are verified by the federation server.
+ *   - Outgoing requests use an https.Agent built from those credentials and
+ *     are dispatched via `https.request` (Node's global `fetch`/undici does
+ *     NOT honor https.Agent, so we must not use it for federation calls).
+ *   - Incoming requests are verified by the federation server, including
+ *     CN/SAN pinning against `trustedPeerCNs`.
  *
  * A bearer-token fallback is supported for dev / air-gapped trust models
  * where mTLS PKI is not available. The fallback is opt-in via
- * `FederationTlsConfig.bearerToken` and logs a security warning at startup.
+ * `FederationTlsConfig.bearerToken`, logs a security warning at startup,
+ * and uses a constant-time comparison.
  *
  * Sensitive-data egress guarantee (AIG-652 #5):
  *   - `submitTask` calls `sanitizeDelegation` to truncate the input to
@@ -18,8 +22,11 @@
  *     by the transport. The federation protocol only carries task metadata.
  */
 
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
+import * as http from 'node:http';
 import * as https from 'node:https';
+import { URL } from 'node:url';
 import { logger } from '../utils/logger.js';
 import type {
   FederationTlsConfig,
@@ -31,6 +38,12 @@ import type {
 const log = logger.child('federation:transport');
 
 /**
+ * Maximum bytes accepted in any single federation HTTP response body
+ * (also used as a default request body cap on the server side).
+ */
+export const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MiB
+
+/**
  * Materialized credentials in memory. `null` fields mean "not configured".
  */
 export interface FederationCredentials {
@@ -39,14 +52,23 @@ export interface FederationCredentials {
   ca: Buffer | null;
   bearerToken: string | null;
   requireClientCert: boolean;
+  /** CN/SAN values we accept from peers (mTLS pinning). Empty = accept any CA-signed cert. */
+  trustedPeerCNs: string[];
+  /** When true, plaintext HTTP fallback is forbidden; missing cert files throw. */
+  allowPlainText: boolean;
 }
 
 /**
- * Load mTLS material from disk. Missing files do NOT throw - they degrade
- * to "bearer token" mode (or unauthenticated, which is logged loudly).
+ * Load mTLS material from disk.
  *
- * This centralizes credential parsing so the rest of the federation module
- * never reads from the filesystem directly.
+ * Security posture rules:
+ *   - If `tls.certPath` / `tls.keyPath` are set but the file is missing or
+ *     unreadable → THROW. We never silently downgrade a configured TLS
+ *     deployment to plain HTTP. (AIG-652 review fix #3.)
+ *   - If `tls.allowPlainText` is false (default) and no cert/key are
+ *     configured AND no bearer token is configured → THROW. The operator
+ *     must opt-in to plaintext explicitly.
+ *   - Bearer-only mode is permitted but logged loudly.
  */
 export function loadCredentials(tls: FederationTlsConfig | undefined): FederationCredentials {
   const creds: FederationCredentials = {
@@ -55,52 +77,62 @@ export function loadCredentials(tls: FederationTlsConfig | undefined): Federatio
     ca: null,
     bearerToken: tls?.bearerToken ?? null,
     requireClientCert: tls?.requireClientCert ?? true,
+    trustedPeerCNs: Array.isArray(tls?.trustedPeerCNs) ? [...(tls?.trustedPeerCNs ?? [])] : [],
+    allowPlainText: tls?.allowPlainText ?? false,
   };
 
   if (tls?.certPath) {
-    try {
-      creds.cert = fs.readFileSync(tls.certPath);
-    } catch (err) {
-      log.warn('Failed to read federation cert', {
-        path: tls.certPath,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+    creds.cert = readRequiredFile(tls.certPath, 'cert');
   }
   if (tls?.keyPath) {
-    try {
-      creds.key = fs.readFileSync(tls.keyPath);
-    } catch (err) {
-      log.warn('Failed to read federation key', {
-        path: tls.keyPath,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+    creds.key = readRequiredFile(tls.keyPath, 'key');
   }
   if (tls?.caPath) {
-    try {
-      creds.ca = fs.readFileSync(tls.caPath);
-    } catch (err) {
-      log.warn('Failed to read federation CA bundle', {
-        path: tls.caPath,
-        error: err instanceof Error ? err.message : String(err),
-      });
-    }
+    creds.ca = readRequiredFile(tls.caPath, 'CA bundle');
+  }
+
+  // If only one of cert/key is provided, that's a misconfiguration.
+  if ((creds.cert && !creds.key) || (!creds.cert && creds.key)) {
+    throw new Error(
+      'Federation TLS misconfiguration: both certPath and keyPath must be set together.'
+    );
+  }
+
+  const haveMtls = !!(creds.cert && creds.key);
+
+  // Fail-closed on missing security material.
+  if (!haveMtls && !creds.bearerToken && !creds.allowPlainText) {
+    throw new Error(
+      'Federation transport refuses to start unauthenticated. ' +
+        'Configure federation.tls (certPath/keyPath[+caPath]) OR a bearerToken, ' +
+        'OR explicitly set federation.tls.allowPlainText = true for local development.'
+    );
   }
 
   // Loud warnings if the security posture is degraded.
-  if (!creds.cert && !creds.bearerToken) {
+  if (!haveMtls && !creds.bearerToken) {
     log.warn(
-      'Federation transport is UNAUTHENTICATED - no mTLS material and no bearer token. ' +
-        'This is only acceptable for local development. Configure federation.tls in aistack.config.json.'
+      'Federation transport is UNAUTHENTICATED (allowPlainText=true). ' +
+        'Local development only. Configure federation.tls in aistack.config.json for production.'
     );
-  } else if (!creds.cert && creds.bearerToken) {
+  } else if (!haveMtls && creds.bearerToken) {
     log.warn(
       'Federation transport is using a bearer token without mTLS. Prefer mTLS in production deployments.'
     );
   }
 
   return creds;
+}
+
+function readRequiredFile(path: string, label: string): Buffer {
+  try {
+    return fs.readFileSync(path);
+  } catch (err) {
+    throw new Error(
+      `Federation ${label} file is required but could not be read at "${path}": ` +
+        (err instanceof Error ? err.message : String(err))
+    );
+  }
 }
 
 /**
@@ -112,35 +144,101 @@ export function buildHttpsAgent(creds: FederationCredentials): https.Agent {
     key: creds.key ?? undefined,
     ca: creds.ca ?? undefined,
     rejectUnauthorized: !!creds.ca, // only verify peers when we have a CA
+    keepAlive: true,
   });
 }
 
 /**
- * Verify a peer's presented certificate matches the configured CA.
+ * Constant-time comparison for bearer tokens. Pads to equal length first to
+ * avoid leaking the length through the early-return path of `===`.
+ */
+export function timingSafeEqualString(a: string, b: string): boolean {
+  const aBuf = Buffer.from(a, 'utf-8');
+  const bBuf = Buffer.from(b, 'utf-8');
+  const len = Math.max(aBuf.length, bBuf.length);
+  if (len === 0) return aBuf.length === bBuf.length;
+  const aPadded = Buffer.alloc(len, 0);
+  const bPadded = Buffer.alloc(len, 0);
+  aBuf.copy(aPadded);
+  bBuf.copy(bPadded);
+  // Combine the length-check into the boolean so the timing of the overall
+  // function does not branch on length alone.
+  const eq = crypto.timingSafeEqual(aPadded, bPadded);
+  return eq && aBuf.length === bBuf.length;
+}
+
+/**
+ * Peer certificate shape exposed by `tls.TLSSocket.getPeerCertificate()`.
+ * We accept the minimal subset we need (subject.CN and subjectaltname).
+ */
+export interface PeerCertificateLike {
+  subject?: { CN?: string };
+  subjectaltname?: string;
+}
+
+/**
+ * Extract candidate CN/SAN values from a peer certificate.
+ */
+export function extractPeerCertNames(cert: PeerCertificateLike | undefined): string[] {
+  if (!cert) return [];
+  const names: string[] = [];
+  if (cert.subject?.CN) names.push(cert.subject.CN);
+  if (typeof cert.subjectaltname === 'string') {
+    // "DNS:foo.example, DNS:bar.example, IP Address:10.0.0.1"
+    for (const part of cert.subjectaltname.split(',')) {
+      const trimmed = part.trim();
+      const colon = trimmed.indexOf(':');
+      if (colon > 0) {
+        names.push(trimmed.slice(colon + 1).trim());
+      }
+    }
+  }
+  return names;
+}
+
+/**
+ * Verify a peer's presented certificate matches the configured CA and,
+ * when `trustedPeerCNs` is non-empty, also that the CN/SAN is pinned.
  * Called by the federation server during request handling.
  *
  * Returns `true` when the request is acceptable, `false` otherwise.
  */
 export function verifyPeerRequest(
   creds: FederationCredentials,
-  peerCert: { subject?: { CN?: string } } | undefined,
+  peerCert: PeerCertificateLike | undefined,
   bearerHeader: string | undefined
 ): { ok: boolean; reason: string } {
-  // Bearer-token mode
-  if (!creds.cert && creds.bearerToken) {
+  const haveMtls = !!(creds.cert && creds.key);
+
+  // Bearer-token mode (no mTLS configured)
+  if (!haveMtls && creds.bearerToken) {
     if (!bearerHeader) return { ok: false, reason: 'Missing Authorization header' };
     const token = bearerHeader.replace(/^Bearer\s+/i, '').trim();
-    if (token !== creds.bearerToken) return { ok: false, reason: 'Invalid bearer token' };
+    if (!timingSafeEqualString(token, creds.bearerToken)) {
+      return { ok: false, reason: 'Invalid bearer token' };
+    }
     return { ok: true, reason: 'bearer-token' };
   }
   // mTLS mode
   if (creds.requireClientCert) {
-    if (!peerCert || !peerCert.subject?.CN) {
+    const names = extractPeerCertNames(peerCert);
+    if (names.length === 0) {
       return { ok: false, reason: 'Missing or invalid client certificate' };
     }
-    return { ok: true, reason: `mtls:${peerCert.subject.CN}` };
+    if (creds.trustedPeerCNs.length > 0) {
+      const matched = names.find((n) => creds.trustedPeerCNs.includes(n));
+      if (!matched) {
+        return {
+          ok: false,
+          reason: `Peer certificate CN/SAN not in trustedPeerCNs (saw: ${names.join(',')})`,
+        };
+      }
+      return { ok: true, reason: `mtls:${matched}` };
+    }
+    return { ok: true, reason: `mtls:${names[0]}` };
   }
-  // Permissive dev mode
+  // Permissive dev mode (allowPlainText forced, no auth) - allowed only because
+  // loadCredentials() has already enforced the explicit opt-in gate.
   return { ok: true, reason: 'dev-mode' };
 }
 
@@ -168,10 +266,23 @@ export function sanitizeDelegation(
 }
 
 /**
+ * Minimal Response-like shape returned by our `request()` helper. We
+ * intentionally do NOT use the global Response/fetch because Node's
+ * `fetch` (undici) does not honor `https.Agent`, which would silently
+ * skip mTLS for outbound federation calls.
+ */
+export interface FederationResponse {
+  ok: boolean;
+  status: number;
+  body: Buffer;
+  json: <T>() => T;
+  text: () => string;
+}
+
+/**
  * HTTP client used to talk to a remote federation peer.
  */
 export class FederationClient {
-  /** Reserved for future undici Dispatcher integration. */
   private readonly agent: https.Agent;
   private readonly maxInputLength: number;
   private readonly timeoutMs: number;
@@ -200,7 +311,7 @@ export class FederationClient {
         log.debug('Peer capabilities non-ok', { peer: peer.nodeId, status: res.status });
         return null;
       }
-      return (await res.json()) as NodeInfo;
+      return res.json<NodeInfo>();
     } catch (err) {
       log.debug('Peer capabilities failed', {
         peer: peer.nodeId,
@@ -221,7 +332,7 @@ export class FederationClient {
     if (!res.ok) {
       throw new Error(`Federation submitTask ${res.status}`);
     }
-    return (await res.json()) as TaskDelegationResult;
+    return res.json<TaskDelegationResult>();
   }
 
   private peerUrl(peer: NodeInfo, path: string): string {
@@ -230,30 +341,78 @@ export class FederationClient {
     return `${base.replace(/\/$/, '')}${path}`;
   }
 
-  private async request(
+  /**
+   * Dispatch an HTTP(S) request using `http(s).request` directly so the
+   * configured `https.Agent` (with mTLS material) is actually used.
+   *
+   * Body cap (DoS guard): we refuse to read more than MAX_BODY_BYTES from
+   * the peer response and abort the stream.
+   */
+  protected async request(
     url: string,
     method: 'GET' | 'POST',
     body?: unknown
-  ): Promise<Response> {
+  ): Promise<FederationResponse> {
+    const parsed = new URL(url);
+    const isHttps = parsed.protocol === 'https:';
     const headers: Record<string, string> = { 'content-type': 'application/json' };
     if (this.bearer) headers.authorization = `Bearer ${this.bearer}`;
 
-    const ctrl = new AbortController();
-    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
-    try {
-      // NOTE: Node's global `fetch` (undici) does not honor `https.Agent`.
-      // For full mTLS in production, callers should configure a global
-      // undici Dispatcher with the credentials, or replace this with an
-      // `https.request` call. For tests + dev (HTTP, no mTLS) the global
-      // fetch works as-is.
-      return await fetch(url, {
-        method,
-        headers,
-        body: body !== undefined ? JSON.stringify(body) : undefined,
-        signal: ctrl.signal,
-      });
-    } finally {
-      clearTimeout(timer);
+    let bodyBuf: Buffer | null = null;
+    if (body !== undefined) {
+      bodyBuf = Buffer.from(JSON.stringify(body), 'utf-8');
+      headers['content-length'] = String(bodyBuf.length);
     }
+
+    const reqOptions: https.RequestOptions = {
+      method,
+      protocol: parsed.protocol,
+      hostname: parsed.hostname,
+      port: parsed.port ? Number.parseInt(parsed.port, 10) : isHttps ? 443 : 80,
+      path: `${parsed.pathname}${parsed.search}`,
+      headers,
+      timeout: this.timeoutMs,
+    };
+    if (isHttps) {
+      (reqOptions as https.RequestOptions).agent = this.agent;
+    }
+
+    const requester = isHttps ? https.request : http.request;
+
+    return new Promise<FederationResponse>((resolve, reject) => {
+      const req = requester(reqOptions, (res) => {
+        const chunks: Buffer[] = [];
+        let total = 0;
+        let aborted = false;
+        res.on('data', (chunk: Buffer) => {
+          total += chunk.length;
+          if (total > MAX_BODY_BYTES) {
+            aborted = true;
+            res.destroy(new Error('Federation response exceeds 1 MiB cap'));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        res.on('end', () => {
+          if (aborted) return;
+          const buf = Buffer.concat(chunks);
+          const status = res.statusCode ?? 0;
+          resolve({
+            ok: status >= 200 && status < 300,
+            status,
+            body: buf,
+            json: <T>() => JSON.parse(buf.toString('utf-8')) as T,
+            text: () => buf.toString('utf-8'),
+          });
+        });
+        res.on('error', reject);
+      });
+      req.on('timeout', () => {
+        req.destroy(new Error('Federation request timed out'));
+      });
+      req.on('error', reject);
+      if (bodyBuf) req.write(bodyBuf);
+      req.end();
+    });
   }
 }

--- a/src/federation/transport.ts
+++ b/src/federation/transport.ts
@@ -1,0 +1,259 @@
+/**
+ * Transport layer - secure HTTP(S) client + credential management for
+ * peer-to-peer federation.
+ *
+ * Default security posture is mutual TLS (mTLS):
+ *   - The local node loads cert / key / CA from disk via `loadCredentials`.
+ *   - Outgoing requests use an https.Agent built from those credentials.
+ *   - Incoming requests are verified by the federation server.
+ *
+ * A bearer-token fallback is supported for dev / air-gapped trust models
+ * where mTLS PKI is not available. The fallback is opt-in via
+ * `FederationTlsConfig.bearerToken` and logs a security warning at startup.
+ *
+ * Sensitive-data egress guarantee (AIG-652 #5):
+ *   - `submitTask` calls `sanitizeDelegation` to truncate the input to
+ *     `maxInputLength` and to strip unknown keys via an allowlist.
+ *   - No memory entries, source code, or file contents are ever serialized
+ *     by the transport. The federation protocol only carries task metadata.
+ */
+
+import * as fs from 'node:fs';
+import * as https from 'node:https';
+import { logger } from '../utils/logger.js';
+import type {
+  FederationTlsConfig,
+  NodeInfo,
+  TaskDelegation,
+  TaskDelegationResult,
+} from './types.js';
+
+const log = logger.child('federation:transport');
+
+/**
+ * Materialized credentials in memory. `null` fields mean "not configured".
+ */
+export interface FederationCredentials {
+  cert: Buffer | null;
+  key: Buffer | null;
+  ca: Buffer | null;
+  bearerToken: string | null;
+  requireClientCert: boolean;
+}
+
+/**
+ * Load mTLS material from disk. Missing files do NOT throw - they degrade
+ * to "bearer token" mode (or unauthenticated, which is logged loudly).
+ *
+ * This centralizes credential parsing so the rest of the federation module
+ * never reads from the filesystem directly.
+ */
+export function loadCredentials(tls: FederationTlsConfig | undefined): FederationCredentials {
+  const creds: FederationCredentials = {
+    cert: null,
+    key: null,
+    ca: null,
+    bearerToken: tls?.bearerToken ?? null,
+    requireClientCert: tls?.requireClientCert ?? true,
+  };
+
+  if (tls?.certPath) {
+    try {
+      creds.cert = fs.readFileSync(tls.certPath);
+    } catch (err) {
+      log.warn('Failed to read federation cert', {
+        path: tls.certPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  if (tls?.keyPath) {
+    try {
+      creds.key = fs.readFileSync(tls.keyPath);
+    } catch (err) {
+      log.warn('Failed to read federation key', {
+        path: tls.keyPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  if (tls?.caPath) {
+    try {
+      creds.ca = fs.readFileSync(tls.caPath);
+    } catch (err) {
+      log.warn('Failed to read federation CA bundle', {
+        path: tls.caPath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // Loud warnings if the security posture is degraded.
+  if (!creds.cert && !creds.bearerToken) {
+    log.warn(
+      'Federation transport is UNAUTHENTICATED - no mTLS material and no bearer token. ' +
+        'This is only acceptable for local development. Configure federation.tls in aistack.config.json.'
+    );
+  } else if (!creds.cert && creds.bearerToken) {
+    log.warn(
+      'Federation transport is using a bearer token without mTLS. Prefer mTLS in production deployments.'
+    );
+  }
+
+  return creds;
+}
+
+/**
+ * Build an https.Agent that performs mTLS when credentials are available.
+ */
+export function buildHttpsAgent(creds: FederationCredentials): https.Agent {
+  return new https.Agent({
+    cert: creds.cert ?? undefined,
+    key: creds.key ?? undefined,
+    ca: creds.ca ?? undefined,
+    rejectUnauthorized: !!creds.ca, // only verify peers when we have a CA
+  });
+}
+
+/**
+ * Verify a peer's presented certificate matches the configured CA.
+ * Called by the federation server during request handling.
+ *
+ * Returns `true` when the request is acceptable, `false` otherwise.
+ */
+export function verifyPeerRequest(
+  creds: FederationCredentials,
+  peerCert: { subject?: { CN?: string } } | undefined,
+  bearerHeader: string | undefined
+): { ok: boolean; reason: string } {
+  // Bearer-token mode
+  if (!creds.cert && creds.bearerToken) {
+    if (!bearerHeader) return { ok: false, reason: 'Missing Authorization header' };
+    const token = bearerHeader.replace(/^Bearer\s+/i, '').trim();
+    if (token !== creds.bearerToken) return { ok: false, reason: 'Invalid bearer token' };
+    return { ok: true, reason: 'bearer-token' };
+  }
+  // mTLS mode
+  if (creds.requireClientCert) {
+    if (!peerCert || !peerCert.subject?.CN) {
+      return { ok: false, reason: 'Missing or invalid client certificate' };
+    }
+    return { ok: true, reason: `mtls:${peerCert.subject.CN}` };
+  }
+  // Permissive dev mode
+  return { ok: true, reason: 'dev-mode' };
+}
+
+/**
+ * Sanitize an outgoing delegation: enforce an allowlist of keys and
+ * truncate the input. This is the central choke point that enforces the
+ * no-egress-of-sensitive-data guarantee.
+ */
+export function sanitizeDelegation(
+  task: TaskDelegation,
+  maxInputLength: number = 4096
+): TaskDelegation {
+  return {
+    taskId: String(task.taskId),
+    agentType: String(task.agentType),
+    input: typeof task.input === 'string' ? task.input.slice(0, maxInputLength) : '',
+    hints: task.hints
+      ? {
+          requiredCapabilities: task.hints.requiredCapabilities?.slice(0, 16),
+          preferredTags: task.hints.preferredTags?.slice(0, 16),
+          estimatedTokens: typeof task.hints.estimatedTokens === 'number' ? task.hints.estimatedTokens : undefined,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * HTTP client used to talk to a remote federation peer.
+ */
+export class FederationClient {
+  /** Reserved for future undici Dispatcher integration. */
+  private readonly agent: https.Agent;
+  private readonly maxInputLength: number;
+  private readonly timeoutMs: number;
+  private readonly bearer: string | null;
+
+  constructor(creds: FederationCredentials, opts: { maxInputLength?: number; timeoutMs?: number } = {}) {
+    this.agent = buildHttpsAgent(creds);
+    this.maxInputLength = opts.maxInputLength ?? 4096;
+    this.timeoutMs = opts.timeoutMs ?? 10_000;
+    this.bearer = creds.bearerToken;
+  }
+
+  /** Expose the underlying https.Agent (e.g. for advanced callers). */
+  getHttpsAgent(): https.Agent {
+    return this.agent;
+  }
+
+  /**
+   * Fetch the peer's advertised capabilities.
+   */
+  async fetchPeerCapabilities(peer: NodeInfo): Promise<NodeInfo | null> {
+    try {
+      const url = this.peerUrl(peer, '/v1/federation/capabilities');
+      const res = await this.request(url, 'GET');
+      if (!res.ok) {
+        log.debug('Peer capabilities non-ok', { peer: peer.nodeId, status: res.status });
+        return null;
+      }
+      return (await res.json()) as NodeInfo;
+    } catch (err) {
+      log.debug('Peer capabilities failed', {
+        peer: peer.nodeId,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Submit a delegated task to a remote peer. Returns the peer's response
+   * or throws on transport / authorization failure.
+   */
+  async submitTask(peer: NodeInfo, task: TaskDelegation): Promise<TaskDelegationResult> {
+    const url = this.peerUrl(peer, '/v1/federation/task');
+    const safe = sanitizeDelegation(task, this.maxInputLength);
+    const res = await this.request(url, 'POST', safe);
+    if (!res.ok) {
+      throw new Error(`Federation submitTask ${res.status}`);
+    }
+    return (await res.json()) as TaskDelegationResult;
+  }
+
+  private peerUrl(peer: NodeInfo, path: string): string {
+    let base = peer.address;
+    if (!/^https?:\/\//.test(base)) base = `${peer.scheme}://${base}`;
+    return `${base.replace(/\/$/, '')}${path}`;
+  }
+
+  private async request(
+    url: string,
+    method: 'GET' | 'POST',
+    body?: unknown
+  ): Promise<Response> {
+    const headers: Record<string, string> = { 'content-type': 'application/json' };
+    if (this.bearer) headers.authorization = `Bearer ${this.bearer}`;
+
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      // NOTE: Node's global `fetch` (undici) does not honor `https.Agent`.
+      // For full mTLS in production, callers should configure a global
+      // undici Dispatcher with the credentials, or replace this with an
+      // `https.request` call. For tests + dev (HTTP, no mTLS) the global
+      // fetch works as-is.
+      return await fetch(url, {
+        method,
+        headers,
+        body: body !== undefined ? JSON.stringify(body) : undefined,
+        signal: ctrl.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}

--- a/src/federation/types.ts
+++ b/src/federation/types.ts
@@ -127,6 +127,14 @@ export interface TaskDelegationResult {
  *
  * All paths are read from the local filesystem at startup. Never embed
  * certs/keys in the config file itself.
+ *
+ * Security posture:
+ *   - If `certPath` is configured but the file is missing, startup THROWS
+ *     (no silent downgrade to plain HTTP).
+ *   - When `trustedPeerCNs` is non-empty, peer certs MUST present a
+ *     CN/SAN in the list (pinning), in addition to passing the CA chain.
+ *   - `allowPlainText` defaults to `false`; you must explicitly opt-in
+ *     to unauthenticated/plain-HTTP federation (dev only).
  */
 export interface FederationTlsConfig {
   /** Path to the client/server certificate (PEM). */
@@ -139,6 +147,33 @@ export interface FederationTlsConfig {
   requireClientCert?: boolean;
   /** Fallback bearer token for environments without mTLS (NOT recommended in prod). */
   bearerToken?: string;
+  /** Explicit CN/SAN allowlist for peer certs. Empty = accept any CA-signed cert. */
+  trustedPeerCNs?: string[];
+  /** Explicit opt-in for plain HTTP / unauthenticated federation (dev only). */
+  allowPlainText?: boolean;
+}
+
+/**
+ * Discovery beacon signing configuration.
+ *
+ * Discovery beacons (mDNS TXT records, registry payloads) are unauthenticated
+ * by default on the wire. We layer an Ed25519 signature on top so peers can
+ * reject spoofed/poisoned announcements on a hostile LAN.
+ *
+ * - `privateKeyPath` and `publicKeyPath` are PEM Ed25519 keys.
+ * - `trustedPublicKeys` is the allowlist of peer PUBLIC keys (PEM strings).
+ *   When non-empty, unsigned or unknown-signer beacons are dropped.
+ * - When `privateKeyPath`/`publicKeyPath` are unset and `trustedPublicKeys`
+ *   is empty, beacons are unsigned (legacy / dev mode) and a warning is
+ *   logged at startup.
+ */
+export interface FederationDiscoverySigningConfig {
+  /** PEM Ed25519 private key used to sign our outbound beacons. */
+  privateKeyPath?: string;
+  /** PEM Ed25519 public key advertised so peers can register us. */
+  publicKeyPath?: string;
+  /** Allowlist of peer Ed25519 public keys (PEM strings). */
+  trustedPublicKeys?: string[];
 }
 
 /**
@@ -174,6 +209,8 @@ export interface FederationConfig {
   maxInputLength?: number;
   /** TLS configuration. */
   tls?: FederationTlsConfig;
+  /** Discovery beacon signing (Ed25519). */
+  discoverySigning?: FederationDiscoverySigningConfig;
   /** Network timeout for peer calls (ms). */
   requestTimeoutMs?: number;
 }

--- a/src/federation/types.ts
+++ b/src/federation/types.ts
@@ -1,0 +1,192 @@
+/**
+ * Federation types - shared types for multi-machine federation layer.
+ *
+ * AIG-652 introduces a federation module that allows multiple aistack nodes
+ * to discover each other, advertise capabilities, and route task work across
+ * machines without exposing sensitive payload data.
+ */
+
+/**
+ * Capability advertised by a federation node. A capability represents an
+ * agent type the node can run plus optional metadata used for routing
+ * (e.g. concurrency budget, current load, supported models).
+ */
+export interface Capability {
+  /** Capability identifier (typically the agent type, e.g. "coder"). */
+  name: string;
+  /** Capability version (for forward compatibility). */
+  version?: string;
+  /** Max concurrent tasks the node is willing to accept for this capability. */
+  maxConcurrent?: number;
+  /** Optional metadata for capability-match policy. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Information published by a federation node when it joins the cluster.
+ *
+ * NOTE: NodeInfo intentionally does NOT include any task payload, code, or
+ * memory snippets. Only routing-relevant data is advertised, which keeps
+ * the no-egress guarantee documented in docs/FEDERATION.md.
+ */
+export interface NodeInfo {
+  /** Stable node identifier (random UUID at first join, persisted). */
+  nodeId: string;
+  /** Human-readable node name. */
+  name: string;
+  /** Reachable address (host:port or full URL). */
+  address: string;
+  /** TLS/transport scheme: 'https' (mTLS) or 'http' (insecure, dev only). */
+  scheme: 'https' | 'http';
+  /** Capabilities advertised by the node. */
+  capabilities: Capability[];
+  /** Current load (0..1) reported by the node, used by least-loaded policy. */
+  load?: number;
+  /** Tags useful for routing filters (region, env, hardware class, ...). */
+  tags?: string[];
+  /** Last time we successfully fetched capabilities from this node. */
+  lastSeen?: Date;
+  /** Software version of the running aistack node. */
+  version?: string;
+}
+
+/**
+ * Discovery method used by a federation node to find peers.
+ *
+ * - 'mdns'      uses multicast DNS / Bonjour on the local network. Requires
+ *               the optional `bonjour-service` peer dependency.
+ * - 'registry'  uses a central HTTP registry (URL configured separately).
+ * - 'static'    uses the static peer list from configuration (no discovery).
+ */
+export type DiscoveryMethod = 'mdns' | 'registry' | 'static';
+
+/**
+ * Routing policy used by `delegateTask` to pick a peer.
+ *
+ * - 'round-robin'        cycles through peers that advertise the capability.
+ * - 'least-loaded'       picks the peer with lowest reported `load`.
+ * - 'capability-match'   picks the peer whose capability metadata best
+ *                        matches the task hint (tags, model, region).
+ */
+export type RoutingPolicy = 'round-robin' | 'least-loaded' | 'capability-match';
+
+/**
+ * Task delegation request sent from coordinator to a remote node.
+ *
+ * NOTE: `input` should be redacted task metadata, never source code or
+ * other sensitive payload. The transport layer enforces this by stripping
+ * unknown keys before sending.
+ */
+export interface TaskDelegation {
+  /** Task identifier on the origin node. */
+  taskId: string;
+  /** Agent type to spawn on the remote. */
+  agentType: string;
+  /** Sanitized task input (truncated to maxInputLength). */
+  input: string;
+  /** Optional routing hints. */
+  hints?: {
+    requiredCapabilities?: string[];
+    preferredTags?: string[];
+    estimatedTokens?: number;
+  };
+}
+
+/**
+ * Decision returned by the router when delegating a task.
+ *
+ * If `peer` is null, no remote node is suitable and the caller should
+ * execute the task locally. This is the opt-in escape hatch that keeps
+ * the federation layer non-intrusive for existing coordinators.
+ */
+export interface RoutingDecision {
+  /** Chosen peer, or null if no suitable peer was found. */
+  peer: NodeInfo | null;
+  /** Reason text useful for logging and debugging. */
+  reason: string;
+  /** Policy that produced this decision. */
+  policy: RoutingPolicy;
+}
+
+/**
+ * Result returned by a remote node after running a delegated task.
+ */
+export interface TaskDelegationResult {
+  taskId: string;
+  status: 'completed' | 'failed' | 'rejected';
+  /** Sanitized result (no raw code / no memory dumps). */
+  summary?: string;
+  /** Error message when status === 'failed'. */
+  error?: string;
+  /** Remote node id that produced the result. */
+  executedBy: string;
+}
+
+/**
+ * TLS configuration for mTLS transport.
+ *
+ * All paths are read from the local filesystem at startup. Never embed
+ * certs/keys in the config file itself.
+ */
+export interface FederationTlsConfig {
+  /** Path to the client/server certificate (PEM). */
+  certPath?: string;
+  /** Path to the private key (PEM). */
+  keyPath?: string;
+  /** Path to the CA bundle used to verify peers (PEM). */
+  caPath?: string;
+  /** When true, refuse connections from peers without a valid client cert. */
+  requireClientCert?: boolean;
+  /** Fallback bearer token for environments without mTLS (NOT recommended in prod). */
+  bearerToken?: string;
+}
+
+/**
+ * Federation configuration consumed by `createFederation()`.
+ *
+ * Sibling of the existing top-level config slots — adding the federation
+ * key does not require touching any other module.
+ */
+export interface FederationConfig {
+  /** Master switch. When false, the federation module is a no-op. */
+  enabled: boolean;
+  /** Stable node id (auto-generated if absent). */
+  nodeId?: string;
+  /** Human-readable name for this node. */
+  name?: string;
+  /** Discovery strategy. */
+  discoveryMethod: DiscoveryMethod;
+  /** Whether to advertise this node's capabilities to peers. */
+  advertise: boolean;
+  /** Static peer list (used by 'static' discovery and as bootstrap for others). */
+  peers: string[];
+  /** Registry URL for 'registry' discovery. */
+  registryUrl?: string;
+  /** mDNS service type, default '_aistack._tcp.local'. */
+  mdnsServiceType?: string;
+  /** Bind address for the federation server. */
+  bindAddress?: string;
+  /** Bind port for the federation server. */
+  bindPort?: number;
+  /** Routing policy used by delegateTask when none is explicitly passed. */
+  routingPolicy: RoutingPolicy;
+  /** Hard cap on task input size sent over the wire (chars). Default 4096. */
+  maxInputLength?: number;
+  /** TLS configuration. */
+  tls?: FederationTlsConfig;
+  /** Network timeout for peer calls (ms). */
+  requestTimeoutMs?: number;
+}
+
+/**
+ * Status snapshot returned by `aistack federation status`.
+ */
+export interface FederationStatus {
+  enabled: boolean;
+  nodeId: string;
+  name: string;
+  address: string;
+  peers: NodeInfo[];
+  discoveryMethod: DiscoveryMethod;
+  joinedAt?: Date;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,7 @@ export interface AgentStackConfig {
   guardrails?: GuardrailsConfig;
   /** Authentication config (extended for SSO via auth.sso sub-field). AIG-646. */
   auth?: AuthConfig;
+  federation?: FederationConfig;
 }
 
 // AIG-636 — daemon (background headless runner) config. Optional sibling field.
@@ -541,6 +542,35 @@ export interface AuthConfig {
     defaultRole?: 'admin' | 'developer' | 'viewer';
     strictIdentityBinding?: boolean;
   };
+}
+
+// Federation types (multi-machine federation, AIG-652)
+export type FederationDiscoveryMethod = 'mdns' | 'registry' | 'static';
+export type FederationRoutingPolicy = 'round-robin' | 'least-loaded' | 'capability-match';
+
+export interface FederationTlsConfig {
+  certPath?: string;
+  keyPath?: string;
+  caPath?: string;
+  requireClientCert?: boolean;
+  bearerToken?: string;
+}
+
+export interface FederationConfig {
+  enabled: boolean;
+  nodeId?: string;
+  name?: string;
+  discoveryMethod: FederationDiscoveryMethod;
+  advertise: boolean;
+  peers: string[];
+  registryUrl?: string;
+  mdnsServiceType?: string;
+  bindAddress?: string;
+  bindPort?: number;
+  routingPolicy: FederationRoutingPolicy;
+  maxInputLength?: number;
+  tls?: FederationTlsConfig;
+  requestTimeoutMs?: number;
 }
 
 export interface MemoryConfig {

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -328,6 +328,16 @@ const FederationTlsConfigSchema = z.object({
   caPath: z.string().optional(),
   requireClientCert: z.boolean().default(true),
   bearerToken: z.string().optional(),
+  /** CN/SAN allowlist for peer certs. Empty array = accept any CA-signed cert. */
+  trustedPeerCNs: z.array(z.string()).default([]),
+  /** Explicit opt-in for plain HTTP / unauthenticated federation (dev only). */
+  allowPlainText: z.boolean().default(false),
+});
+
+const FederationDiscoverySigningConfigSchema = z.object({
+  privateKeyPath: z.string().optional(),
+  publicKeyPath: z.string().optional(),
+  trustedPublicKeys: z.array(z.string()).default([]),
 });
 
 /**
@@ -350,6 +360,7 @@ const FederationConfigSchema = z.object({
   routingPolicy: z.enum(['round-robin', 'least-loaded', 'capability-match']).default('least-loaded'),
   maxInputLength: z.number().min(64).max(65536).default(4096),
   tls: FederationTlsConfigSchema.optional(),
+  discoverySigning: FederationDiscoverySigningConfigSchema.optional(),
   requestTimeoutMs: z.number().min(100).max(120000).default(10000),
 });
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -200,6 +200,7 @@ const ConsensusConfigSchema = z.object({
   ]),
 });
 
+<<<<<<< HEAD
 /**
  * Telemetry Configuration Schema (AIG-655)
  *
@@ -319,6 +320,37 @@ const GuardrailsConfigSchema = z.object({
   customPaths: z.array(z.string()).optional(),
   timeoutMs: z.number().min(50).max(60000).default(2000),
   killSwitch: z.boolean().default(true),
+});
+
+const FederationTlsConfigSchema = z.object({
+  certPath: z.string().optional(),
+  keyPath: z.string().optional(),
+  caPath: z.string().optional(),
+  requireClientCert: z.boolean().default(true),
+  bearerToken: z.string().optional(),
+});
+
+/**
+ * Federation configuration (AIG-652).
+ *
+ * Sibling slot - additive only. When `enabled` is false the federation
+ * module is a no-op and nothing else in aistack is affected.
+ */
+const FederationConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  nodeId: z.string().optional(),
+  name: z.string().optional(),
+  discoveryMethod: z.enum(['mdns', 'registry', 'static']).default('static'),
+  advertise: z.boolean().default(false),
+  peers: z.array(z.string()).default([]),
+  registryUrl: z.string().optional(),
+  mdnsServiceType: z.string().default('_aistack._tcp.local'),
+  bindAddress: z.string().default('0.0.0.0'),
+  bindPort: z.number().min(0).max(65535).default(0),
+  routingPolicy: z.enum(['round-robin', 'least-loaded', 'capability-match']).default('least-loaded'),
+  maxInputLength: z.number().min(64).max(65536).default(4096),
+  tls: FederationTlsConfigSchema.optional(),
+  requestTimeoutMs: z.number().min(100).max(120000).default(10000),
 });
 
 const SmartDispatcherConfigSchema = z.object({
@@ -454,6 +486,7 @@ const ConfigSchema = z.object({
   integrations: IntegrationsConfigSchema.optional(),
   guardrails: GuardrailsConfigSchema.default({}),
   auth: AuthConfigSchema.optional(),
+  federation: FederationConfigSchema.default({}),
 });
 
 const CONFIG_FILE_NAME = 'aistack.config.json';

--- a/tests/integration/federation-3node.test.ts
+++ b/tests/integration/federation-3node.test.ts
@@ -41,6 +41,10 @@ async function makeNode(
     bindAddress: '127.0.0.1',
     bindPort: 0,
     routingPolicy: 'least-loaded',
+    // Test fixture runs over plain HTTP loopback. Production deployments
+    // MUST configure tls.certPath + keyPath; opting into plaintext is the
+    // explicit dev-only path enforced by loadCredentials().
+    tls: { allowPlainText: true },
   });
   manager.setLocalCapabilities(capabilities);
   manager.setTaskHandler(async (task: TaskDelegation) => ({

--- a/tests/integration/federation-3node.test.ts
+++ b/tests/integration/federation-3node.test.ts
@@ -1,0 +1,158 @@
+/**
+ * 3-node federation integration test.
+ *
+ * Spins up three FederationManager instances on local loopback ports, each
+ * acting as a peer. Verifies that:
+ *
+ *   1. Node A's router selects either node B or node C for a task that
+ *      advertises a matching capability (acceptance criterion #4).
+ *   2. The chosen peer executes the task and returns a sanitized result
+ *      with `executedBy` set to its own nodeId.
+ *   3. The transport sanitizer truncates oversized input (no-egress
+ *      sensitive-payload guarantee, acceptance criterion #5).
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  createFederation,
+  FederationManager,
+  sanitizeDelegation,
+  type NodeInfo,
+  type TaskDelegation,
+} from '../../src/federation/index.js';
+
+interface Node {
+  manager: FederationManager;
+  port: number;
+  nodeId: string;
+}
+
+async function makeNode(
+  name: string,
+  capabilities: { name: string; enabled: boolean }[],
+  peers: string[] = []
+): Promise<Node> {
+  const manager = createFederation({
+    enabled: true,
+    name,
+    discoveryMethod: 'static',
+    advertise: false,
+    peers,
+    bindAddress: '127.0.0.1',
+    bindPort: 0,
+    routingPolicy: 'least-loaded',
+  });
+  manager.setLocalCapabilities(capabilities);
+  manager.setTaskHandler(async (task: TaskDelegation) => ({
+    taskId: task.taskId,
+    status: 'completed',
+    summary: `ran ${task.agentType} on ${name}`,
+    executedBy: '', // populated by manager
+  }));
+  await manager.join();
+  const status = manager.status();
+  // status.address is scheme://host:port
+  const url = new URL(status.address);
+  return { manager, port: Number.parseInt(url.port, 10), nodeId: status.nodeId };
+}
+
+describe('Federation 3-node cluster', () => {
+  let nodeA: Node;
+  let nodeB: Node;
+  let nodeC: Node;
+
+  beforeEach(async () => {
+    // Start B and C first so we have addresses for A's peer list.
+    nodeB = await makeNode('node-b', [{ name: 'coder', enabled: true }]);
+    nodeC = await makeNode('node-c', [{ name: 'coder', enabled: true }]);
+    const peers = [
+      `http://127.0.0.1:${nodeB.port}`,
+      `http://127.0.0.1:${nodeC.port}`,
+    ];
+    nodeA = await makeNode('node-a', [{ name: 'coordinator', enabled: true }], peers);
+    // Register the static peers with proper NodeInfo by manually telling A
+    // their nodeIds. In a real cluster discovery would do this; here we
+    // patch via fetchPeerCapabilities to refresh metadata.
+    const aPeers: NodeInfo[] = nodeA.manager.peers();
+    for (const peer of aPeers) {
+      const refreshed = await nodeA.manager.fetchPeerCapabilities(peer);
+      if (refreshed) {
+        // Replace static placeholder with the real id+caps
+        peer.nodeId = refreshed.nodeId;
+        peer.capabilities = refreshed.capabilities;
+        peer.name = refreshed.name;
+      }
+    }
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      nodeA?.manager.leave(),
+      nodeB?.manager.leave(),
+      nodeC?.manager.leave(),
+    ]);
+  });
+
+  it('routes a task spawned on node A to either node B or node C', () => {
+    const task: TaskDelegation = {
+      taskId: 'task-1',
+      agentType: 'coder',
+      input: 'write hello world',
+    };
+    const decision = nodeA.manager.delegateTask(task);
+    expect(decision.peer).not.toBeNull();
+    expect([nodeB.nodeId, nodeC.nodeId]).toContain(decision.peer!.nodeId);
+  });
+
+  it('submits the task and receives a completed result from the chosen peer', async () => {
+    const task: TaskDelegation = {
+      taskId: 'task-2',
+      agentType: 'coder',
+      input: 'do something safe',
+    };
+    const decision = nodeA.manager.delegateTask(task);
+    expect(decision.peer).not.toBeNull();
+    const result = await nodeA.manager.submitTask(decision.peer!, task);
+    expect(result.status).toBe('completed');
+    expect(result.summary).toMatch(/ran coder/);
+    expect(result.executedBy).toBe(decision.peer!.nodeId);
+  });
+
+  it('returns no peer when no node advertises the capability', () => {
+    const task: TaskDelegation = {
+      taskId: 'task-3',
+      agentType: 'security-auditor',
+      input: 'audit',
+    };
+    const decision = nodeA.manager.delegateTask(task);
+    expect(decision.peer).toBeNull();
+  });
+});
+
+describe('Federation no-egress guarantee', () => {
+  it('sanitizeDelegation truncates oversized input and strips unknown keys', () => {
+    const huge = 'x'.repeat(10_000);
+    const dirty = {
+      taskId: 't',
+      agentType: 'coder',
+      input: huge,
+      // Unknown keys must be dropped
+      secrets: { apiKey: 'leak-me' },
+      filePayload: 'malicious',
+      hints: {
+        requiredCapabilities: ['coder'],
+        preferredTags: ['gpu'],
+        estimatedTokens: 1234,
+        // Unknown hint keys must be dropped
+        leaking: 'nope',
+      },
+    } as unknown as TaskDelegation;
+
+    const clean = sanitizeDelegation(dirty, 1024);
+    expect(clean.input.length).toBe(1024);
+    expect((clean as unknown as Record<string, unknown>).secrets).toBeUndefined();
+    expect((clean as unknown as Record<string, unknown>).filePayload).toBeUndefined();
+    expect(clean.hints?.estimatedTokens).toBe(1234);
+    expect((clean.hints as unknown as Record<string, unknown>).leaking).toBeUndefined();
+  });
+});

--- a/tests/unit/federation/routing.test.ts
+++ b/tests/unit/federation/routing.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Routing policy tests - round-robin, least-loaded, capability-match.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { TaskRouter } from '../../../src/federation/routing.js';
+import type { NodeInfo, TaskDelegation } from '../../../src/federation/types.js';
+
+function makePeer(id: string, opts: Partial<NodeInfo> = {}): NodeInfo {
+  return {
+    nodeId: id,
+    name: id,
+    address: `https://${id}:8443`,
+    scheme: 'https',
+    capabilities: [{ name: 'coder', enabled: true }],
+    load: 0,
+    tags: [],
+    ...opts,
+  };
+}
+
+function makeTask(agentType: string = 'coder', hints?: TaskDelegation['hints']): TaskDelegation {
+  return { taskId: 't1', agentType, input: 'do work', hints };
+}
+
+describe('TaskRouter', () => {
+  describe('capability filtering', () => {
+    it('returns peer=null when no peer advertises the capability', () => {
+      const router = new TaskRouter();
+      const peers = [makePeer('a', { capabilities: [{ name: 'researcher', enabled: true }] })];
+      const decision = router.delegateTask(makeTask('coder'), peers, 'round-robin');
+      expect(decision.peer).toBeNull();
+      expect(decision.reason).toMatch(/No peer/);
+    });
+
+    it('filters by requiredCapabilities hint (all must be present)', () => {
+      const router = new TaskRouter();
+      const peers = [
+        makePeer('a', {
+          capabilities: [
+            { name: 'coder', enabled: true },
+            { name: 'tester', enabled: true },
+          ],
+        }),
+        makePeer('b', { capabilities: [{ name: 'coder', enabled: true }] }),
+      ];
+      const decision = router.delegateTask(
+        makeTask('coder', { requiredCapabilities: ['tester'] }),
+        peers,
+        'round-robin'
+      );
+      expect(decision.peer?.nodeId).toBe('a');
+    });
+  });
+
+  describe('round-robin policy', () => {
+    it('cycles through candidate peers', () => {
+      const router = new TaskRouter();
+      const peers = [makePeer('a'), makePeer('b'), makePeer('c')];
+      const ids = [
+        router.delegateTask(makeTask(), peers, 'round-robin').peer?.nodeId,
+        router.delegateTask(makeTask(), peers, 'round-robin').peer?.nodeId,
+        router.delegateTask(makeTask(), peers, 'round-robin').peer?.nodeId,
+        router.delegateTask(makeTask(), peers, 'round-robin').peer?.nodeId,
+      ];
+      expect(ids).toEqual(['a', 'b', 'c', 'a']);
+    });
+  });
+
+  describe('least-loaded policy', () => {
+    it('picks the peer with the lowest reported load', () => {
+      const router = new TaskRouter();
+      const peers = [
+        makePeer('a', { load: 0.8 }),
+        makePeer('b', { load: 0.1 }),
+        makePeer('c', { load: 0.5 }),
+      ];
+      const decision = router.delegateTask(makeTask(), peers, 'least-loaded');
+      expect(decision.peer?.nodeId).toBe('b');
+    });
+
+    it('breaks ties via round-robin', () => {
+      const router = new TaskRouter();
+      const peers = [
+        makePeer('a', { load: 0.1 }),
+        makePeer('b', { load: 0.1 }),
+      ];
+      const first = router.delegateTask(makeTask(), peers, 'least-loaded').peer?.nodeId;
+      const second = router.delegateTask(makeTask(), peers, 'least-loaded').peer?.nodeId;
+      expect(new Set([first, second])).toEqual(new Set(['a', 'b']));
+    });
+
+    it('treats missing load as 0', () => {
+      const router = new TaskRouter();
+      const peers = [makePeer('a', { load: 0.5 }), makePeer('b')];
+      const decision = router.delegateTask(makeTask(), peers, 'least-loaded');
+      expect(decision.peer?.nodeId).toBe('b');
+    });
+  });
+
+  describe('capability-match policy', () => {
+    it('prefers peers whose tags match preferredTags', () => {
+      const router = new TaskRouter();
+      const peers = [
+        makePeer('a', { tags: ['eu-west', 'gpu'] }),
+        makePeer('b', { tags: ['us-east'] }),
+      ];
+      const decision = router.delegateTask(
+        makeTask('coder', { preferredTags: ['eu-west'] }),
+        peers,
+        'capability-match'
+      );
+      expect(decision.peer?.nodeId).toBe('a');
+    });
+
+    it('falls back to load when no tags match', () => {
+      const router = new TaskRouter();
+      const peers = [
+        makePeer('a', { tags: ['us-east'], load: 0.9 }),
+        makePeer('b', { tags: ['us-east'], load: 0.1 }),
+      ];
+      const decision = router.delegateTask(
+        makeTask('coder', { preferredTags: ['eu-west'] }),
+        peers,
+        'capability-match'
+      );
+      expect(decision.peer?.nodeId).toBe('b');
+    });
+  });
+
+  describe('decision shape', () => {
+    it('returns the policy and a reason on success', () => {
+      const router = new TaskRouter();
+      const peers = [makePeer('a')];
+      const decision = router.delegateTask(makeTask(), peers, 'round-robin');
+      expect(decision.policy).toBe('round-robin');
+      expect(decision.peer?.nodeId).toBe('a');
+      expect(decision.reason).toMatch(/round-robin/);
+    });
+  });
+});

--- a/tests/unit/federation/security.test.ts
+++ b/tests/unit/federation/security.test.ts
@@ -1,0 +1,387 @@
+/**
+ * Federation security tests (AIG-652 review fixes).
+ *
+ * Covers the 6 blockers raised by the security review:
+ *   1. Outbound HTTPS calls actually use `https.Agent` (mTLS works on the wire).
+ *   2. `verifyPeerRequest` enforces CN/SAN pinning via `trustedPeerCNs`.
+ *   3. Missing cert files cause a hard startup failure (no silent HTTP downgrade).
+ *   4. Discovery beacons are Ed25519-signed and verified on receipt.
+ *   5. Bearer-token comparison is constant-time.
+ *   6. `readJson` enforces a 1 MiB body cap (413 on overflow).
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { PassThrough } from 'node:stream';
+import {
+  buildBeaconSigner,
+  canonicalBeaconPayload,
+  extractPeerCertNames,
+  FederationClient,
+  loadCredentials,
+  MAX_BODY_BYTES,
+  readJson,
+  timingSafeEqualString,
+  verifyBeacon,
+  verifyPeerRequest,
+  type FederationCredentials,
+} from '../../../src/federation/index.js';
+
+// --- helpers ----------------------------------------------------------------
+
+function tempPath(name: string): string {
+  return path.join(os.tmpdir(), `aig-652-${process.pid}-${Date.now()}-${name}`);
+}
+
+function makeBareCreds(overrides: Partial<FederationCredentials> = {}): FederationCredentials {
+  return {
+    cert: null,
+    key: null,
+    ca: null,
+    bearerToken: null,
+    requireClientCert: true,
+    trustedPeerCNs: [],
+    allowPlainText: false,
+    ...overrides,
+  };
+}
+
+// --- Fix #3: missing-cert -> THROW; no silent HTTP downgrade ---------------
+
+describe('loadCredentials: fail-closed on missing material', () => {
+  it('throws when certPath is configured but file is missing', () => {
+    expect(() =>
+      loadCredentials({
+        certPath: path.join(os.tmpdir(), 'definitely-not-here-aig652.pem'),
+        keyPath: path.join(os.tmpdir(), 'definitely-not-here-aig652.key'),
+      })
+    ).toThrow(/cert file is required but could not be read/);
+  });
+
+  it('throws when neither TLS nor bearer is configured and allowPlainText=false', () => {
+    expect(() => loadCredentials({})).toThrow(/refuses to start unauthenticated/);
+    expect(() => loadCredentials(undefined)).toThrow(/refuses to start unauthenticated/);
+  });
+
+  it('accepts bearer-token only mode', () => {
+    const creds = loadCredentials({ bearerToken: 'abc123' });
+    expect(creds.bearerToken).toBe('abc123');
+    expect(creds.cert).toBeNull();
+  });
+
+  it('accepts explicit allowPlainText opt-in (dev mode)', () => {
+    const creds = loadCredentials({ allowPlainText: true });
+    expect(creds.allowPlainText).toBe(true);
+  });
+
+  it('throws when only one of cert/key is set', () => {
+    const certPath = tempPath('cert.pem');
+    fs.writeFileSync(certPath, '---FAKE---');
+    try {
+      expect(() => loadCredentials({ certPath })).toThrow(
+        /both certPath and keyPath must be set together/
+      );
+    } finally {
+      fs.unlinkSync(certPath);
+    }
+  });
+});
+
+// --- Fix #5: constant-time bearer compare -----------------------------------
+
+describe('timingSafeEqualString', () => {
+  it('returns true only for identical strings', () => {
+    expect(timingSafeEqualString('hello', 'hello')).toBe(true);
+    expect(timingSafeEqualString('hello', 'world')).toBe(false);
+  });
+
+  it('returns false for differing-length strings (without leaking via early return)', () => {
+    expect(timingSafeEqualString('short', 'a-much-longer-token')).toBe(false);
+    expect(timingSafeEqualString('', 'nonempty')).toBe(false);
+  });
+
+  it('handles empty strings symmetrically', () => {
+    expect(timingSafeEqualString('', '')).toBe(true);
+  });
+
+  it('does NOT rely on native === early-return semantics', () => {
+    // Smoke-test: the implementation must call crypto.timingSafeEqual on
+    // equal-length buffers. Reaching into the impl via behavior: both
+    // "off-by-first-byte" and "off-by-last-byte" must return false.
+    const base = 'a'.repeat(64);
+    const firstDiff = 'b' + base.slice(1);
+    const lastDiff = base.slice(0, -1) + 'b';
+    expect(timingSafeEqualString(base, firstDiff)).toBe(false);
+    expect(timingSafeEqualString(base, lastDiff)).toBe(false);
+  });
+});
+
+describe('verifyPeerRequest: bearer mode uses constant-time compare', () => {
+  it('accepts the matching bearer token', () => {
+    const creds = makeBareCreds({ bearerToken: 'secret-token', allowPlainText: true });
+    const verdict = verifyPeerRequest(creds, undefined, 'Bearer secret-token');
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('rejects wrong bearer tokens', () => {
+    const creds = makeBareCreds({ bearerToken: 'secret-token', allowPlainText: true });
+    expect(verifyPeerRequest(creds, undefined, 'Bearer wrong-token').ok).toBe(false);
+    expect(verifyPeerRequest(creds, undefined, '').ok).toBe(false);
+    expect(verifyPeerRequest(creds, undefined, undefined).ok).toBe(false);
+  });
+});
+
+// --- Fix #2: CN pinning -----------------------------------------------------
+
+describe('verifyPeerRequest: mTLS CN/SAN pinning', () => {
+  const certBuf = Buffer.from('---CERT---');
+  const keyBuf = Buffer.from('---KEY---');
+
+  it('accepts any CA-signed cert when trustedPeerCNs is empty', () => {
+    const creds = makeBareCreds({
+      cert: certBuf,
+      key: keyBuf,
+      requireClientCert: true,
+      trustedPeerCNs: [],
+    });
+    const verdict = verifyPeerRequest(
+      creds,
+      { subject: { CN: 'random-peer.local' } },
+      undefined
+    );
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toMatch(/mtls:random-peer/);
+  });
+
+  it('rejects a peer cert whose CN is not in the trustedPeerCNs allowlist', () => {
+    const creds = makeBareCreds({
+      cert: certBuf,
+      key: keyBuf,
+      requireClientCert: true,
+      trustedPeerCNs: ['allowed.peer.local'],
+    });
+    const verdict = verifyPeerRequest(
+      creds,
+      { subject: { CN: 'malicious.peer.local' } },
+      undefined
+    );
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/not in trustedPeerCNs/);
+  });
+
+  it('accepts when the SAN matches even if the CN does not', () => {
+    const creds = makeBareCreds({
+      cert: certBuf,
+      key: keyBuf,
+      requireClientCert: true,
+      trustedPeerCNs: ['peer-alt-name'],
+    });
+    const verdict = verifyPeerRequest(
+      creds,
+      {
+        subject: { CN: 'unrelated.local' },
+        subjectaltname: 'DNS:peer-alt-name, DNS:other.local',
+      },
+      undefined
+    );
+    expect(verdict.ok).toBe(true);
+    expect(verdict.reason).toMatch(/peer-alt-name/);
+  });
+
+  it('rejects when no peer cert is presented at all', () => {
+    const creds = makeBareCreds({
+      cert: certBuf,
+      key: keyBuf,
+      requireClientCert: true,
+      trustedPeerCNs: ['allowed.peer.local'],
+    });
+    const verdict = verifyPeerRequest(creds, undefined, undefined);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/Missing or invalid client certificate/);
+  });
+});
+
+describe('extractPeerCertNames', () => {
+  it('parses subjectaltname into individual entries', () => {
+    const names = extractPeerCertNames({
+      subject: { CN: 'cn.example' },
+      subjectaltname: 'DNS:san1.example, DNS:san2.example, IP Address:10.0.0.1',
+    });
+    expect(names).toEqual(['cn.example', 'san1.example', 'san2.example', '10.0.0.1']);
+  });
+});
+
+// --- Fix #1: outbound mTLS actually uses https.Agent -----------------------
+
+describe('FederationClient outbound uses configured https.Agent', () => {
+  it('passes the credential-built agent to https.request', async () => {
+    const creds = makeBareCreds({
+      cert: Buffer.from('---FAKE-CERT---'),
+      key: Buffer.from('---FAKE-KEY---'),
+      ca: Buffer.from('---FAKE-CA---'),
+      requireClientCert: true,
+    });
+    const client = new FederationClient(creds, { timeoutMs: 250 });
+    const agent = client.getHttpsAgent();
+
+    let seenOptions: https.RequestOptions | null = null;
+    const spy = vi.spyOn(https, 'request').mockImplementation(((
+      options: https.RequestOptions,
+      cb?: (res: http.IncomingMessage) => void
+    ) => {
+      seenOptions = options;
+      const fakeRes = new PassThrough() as unknown as http.IncomingMessage;
+      (fakeRes as unknown as { statusCode: number }).statusCode = 200;
+      const fakeReq = new PassThrough();
+      // Fire callback + end body asynchronously so the client promise resolves.
+      setImmediate(() => {
+        if (cb) cb(fakeRes);
+        (fakeRes as unknown as PassThrough).end('{}');
+      });
+      // The transport calls req.on('timeout',..), req.on('error',..), req.end()
+      // PassThrough supports all of those.
+      return fakeReq as unknown as ReturnType<typeof https.request>;
+    }) as unknown as typeof https.request);
+
+    try {
+      await client.fetchPeerCapabilities({
+        nodeId: 'p',
+        name: 'p',
+        address: 'https://peer.local:9443',
+        scheme: 'https',
+        capabilities: [],
+      });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(seenOptions).not.toBeNull();
+    // CRITICAL assertion: the configured Agent (mTLS material) is actually
+    // used for the outbound HTTPS call. The previous implementation used
+    // global `fetch`, which silently dropped the agent.
+    expect((seenOptions as https.RequestOptions).agent).toBe(agent);
+  });
+});
+
+// --- Fix #4: signed discovery beacons --------------------------------------
+
+describe('Beacon Ed25519 signing & verification', () => {
+  const tmpKeys: string[] = [];
+  afterEach(() => {
+    for (const p of tmpKeys.splice(0)) {
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  function writeKeyPair(): { priv: string; pub: string; privPem: string; pubPem: string } {
+    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519');
+    const privPem = privateKey.export({ format: 'pem', type: 'pkcs8' }).toString();
+    const pubPem = publicKey.export({ format: 'pem', type: 'spki' }).toString();
+    const priv = tempPath('ed25519.priv.pem');
+    const pub = tempPath('ed25519.pub.pem');
+    fs.writeFileSync(priv, privPem);
+    fs.writeFileSync(pub, pubPem);
+    tmpKeys.push(priv, pub);
+    return { priv, pub, privPem, pubPem };
+  }
+
+  it('signs the canonical payload and verifies it round-trip', () => {
+    const { priv, pub, pubPem } = writeKeyPair();
+    const signer = buildBeaconSigner({
+      privateKeyPath: priv,
+      publicKeyPath: pub,
+      trustedPublicKeys: [pubPem],
+    });
+
+    const node = {
+      nodeId: 'n1',
+      name: 'n1',
+      address: 'https://10.0.0.1:9443',
+      scheme: 'https' as const,
+      capabilities: [{ name: 'coder', enabled: true }],
+    };
+    const seq = 42;
+    const payload = canonicalBeaconPayload(node, seq);
+    const sig = signer.sign!(payload);
+    const verdict = verifyBeacon(signer, payload, sig, pubPem);
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('rejects unsigned beacons when trustedPublicKeys is set', () => {
+    const { pubPem } = writeKeyPair();
+    const signer = buildBeaconSigner({ trustedPublicKeys: [pubPem] });
+    const verdict = verifyBeacon(signer, 'anything', undefined, undefined);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/unsigned/);
+  });
+
+  it('rejects beacons signed by a non-trusted key', () => {
+    const trusted = writeKeyPair();
+    const attacker = writeKeyPair();
+    const signer = buildBeaconSigner({ trustedPublicKeys: [trusted.pubPem] });
+    const payload = 'beacon-body';
+    const attackerKey = crypto.createPrivateKey({ key: attacker.privPem, format: 'pem' });
+    const sig = crypto.sign(null, Buffer.from(payload, 'utf-8'), attackerKey).toString('base64');
+    const verdict = verifyBeacon(signer, payload, sig, attacker.pubPem);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/not in trustedPublicKeys/);
+  });
+
+  it('rejects a tampered payload (signature no longer matches)', () => {
+    const { priv, pub, pubPem } = writeKeyPair();
+    const signer = buildBeaconSigner({
+      privateKeyPath: priv,
+      publicKeyPath: pub,
+      trustedPublicKeys: [pubPem],
+    });
+    const payload = 'original-payload';
+    const sig = signer.sign!(payload);
+    const verdict = verifyBeacon(signer, 'tampered-payload', sig, pubPem);
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/invalid signature/);
+  });
+});
+
+// --- Fix #6: body cap on incoming JSON --------------------------------------
+
+describe('readJson: 1 MiB body cap', () => {
+  function makeReq(body: Buffer): http.IncomingMessage {
+    const stream = new PassThrough();
+    setImmediate(() => {
+      stream.end(body);
+    });
+    return stream as unknown as http.IncomingMessage;
+  }
+
+  it('parses small JSON bodies', async () => {
+    const req = makeReq(Buffer.from(JSON.stringify({ hello: 'world' })));
+    const result = await readJson<{ hello: string }>(req);
+    expect(result.tooLarge).toBe(false);
+    expect(result.value).toEqual({ hello: 'world' });
+  });
+
+  it('rejects bodies larger than the cap (signals tooLarge=true)', async () => {
+    // 1 MiB + 1 byte
+    const big = Buffer.alloc(MAX_BODY_BYTES + 1, 0x61);
+    const req = makeReq(big);
+    const result = await readJson(req, MAX_BODY_BYTES);
+    expect(result.tooLarge).toBe(true);
+    expect(result.value).toBeNull();
+  });
+
+  it('honors a custom (smaller) cap', async () => {
+    const body = Buffer.alloc(2048, 0x61); // 2 KiB
+    const req = makeReq(body);
+    const result = await readJson(req, 1024); // 1 KiB cap
+    expect(result.tooLarge).toBe(true);
+  });
+});


### PR DESCRIPTION
﻿Implements [AIG-652](https://linear.app/aigensolutionsit/issue/AIG-652).

**Milestone**: M3 - Enterprise
**Estimate**: 8 pts

## Summary
See commit message for full implementation details (schema, API, CLI, tests, docs).

## Notes from PM agent
Discovery + TLS + mutual auth + CRDT-based replication. Ruflo v3.6-style.

---
Auto-opened by aistack PM agent on 2026-05-28 10:22. Review with /review or human dispatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-machine federation support enabling nodes to discover peers and delegate tasks across a network
  * Added `federation` CLI commands for joining/leaving federation networks and viewing node/peer status
  * Added configurable federation security with mTLS and bearer-token authentication options

* **Documentation**
  * Added federation guide covering setup, configuration, security, and troubleshooting

* **Tests**
  * Added integration and unit tests validating federation discovery, task routing, and security controls

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackms/aistack/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->