### PR TITLE
AIG-631 Add M0 agentic TDD workflow and README positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # aistack
 
-### Ultra-Modern Multi-Agent Orchestration for Claude Code
+## Claude Code's adversarial layer for code that survives review
 
 [![npm version](https://img.shields.io/npm/v/@blackms/aistack?style=for-the-badge&color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@blackms/aistack)
 [![npm downloads](https://img.shields.io/npm/dw/@blackms/aistack?style=for-the-badge&color=CB3837&logo=npm&logoColor=white&label=downloads%2Fweek)](https://www.npmjs.com/package/@blackms/aistack)
@@ -18,15 +18,37 @@
 
 <br/>
 
-**Production-grade agent orchestration with adversarial validation, persistent memory, and real-time web dashboard.**
+**Spawn specialized local agents that write, attack, fix, and gate code before it reaches your PR.**
 
 <br/>
 
-[Quick Start](#-quick-start) · [What It Does](#what-it-does) · [Features](#-features) · [Documentation](#-documentation)
+<table>
+<tr>
+<td align="left" width="33%">
+<b>Adversarial code review</b><br/>
+Coder and adversarial agents iterate until approval or max rounds.<br/>
+<sub>Proof: <code>createReviewLoop</code> plus REST/web review-loop routes.</sub>
+</td>
+<td align="left" width="33%">
+<b>Local-first Claude Code orchestration</b><br/>
+Run the NPM package, stdio MCP server, and SQLite memory on your machine.<br/>
+<sub>Proof: 46 MCP tools wired into Claude Code.</sub>
+</td>
+<td align="left" width="33%">
+<b>Governable autonomy</b><br/>
+Keep agents bounded with consensus checkpoints, drift checks, and resource limits.<br/>
+<sub>Proof: risk gates, audit trails, and resource exhaustion monitoring.</sub>
+</td>
+</tr>
+</table>
 
 <br/>
 
-```
+[Quick Start](#-quick-start) · [Who should use](#who-should-use-aistack) · [Features](#-features) · [Documentation](#-documentation)
+
+<br/>
+
+```text
 11 agents · 46 MCP tools · 6 LLM providers · SQLite + FTS5 · Web dashboard · Agent Identity · Drift Detection · Consensus Checkpoints · Resource Monitoring
 ```
 
@@ -36,43 +58,41 @@
 
 ## What It Does
 
-aistack helps you **coordinate multiple specialized AI agents** to work together on complex tasks. Think of it as a team of AI specialists:
+aistack turns Claude Code into a local multi-agent delivery loop: one agent writes, another attacks the result, tests gate the change, and the outcome is captured for the next run.
 
-**Instead of asking one AI to do everything, you can:**
-- Spawn a **Coder** agent to write code
-- Spawn an **Adversarial** agent to review and break it
-- Spawn a **Tester** agent to write tests
-- Spawn a **Documentation** agent to document it
-- Store learnings in **persistent memory** for future use
+Use it when a task needs more than one model role:
+- **Ship reviewed code** - Coder, tester, reviewer, and adversarial agents iterate until the work is approved or rejected with concrete findings.
+- **Keep local control** - The NPM package runs from your machine with a stdio MCP server, SQLite memory, and no hosted control plane requirement.
+- **Bound agent autonomy** - Consensus checkpoints, semantic drift detection, and resource exhaustion monitoring keep risky or runaway work visible.
+- **Carry context forward** - Persistent memory stores patterns, decisions, and implementation notes for later Claude Code sessions.
 
-**How it works:**
-1. **Spawn specialized agents** - Each agent has specific expertise (coding, testing, reviewing, etc.)
-2. **They communicate through a message bus** - Agents can coordinate and share information
-3. **Memory persists across sessions** - Agents remember patterns, decisions, and learnings
-4. **Adversarial validation** - Code is automatically reviewed and improved through iterative feedback
-5. **Integrate with Claude Code** - Use agents directly from your IDE via MCP protocol
+### Example workflow
 
-**Perfect for:**
-- Code generation with automatic review cycles
-- Multi-step development workflows (design → code → test → document)
-- Building institutional knowledge that persists across projects
-- Automating complex tasks that need different types of expertise
-
-### Example Workflow
-
-```
+```text
 You ask: "Create a login API endpoint with tests"
 
 aistack:
-1. Spawns a Coder agent → writes the API code
-2. Spawns an Adversarial agent → tries to break it, finds security issues
-3. Coder fixes the issues
-4. Spawns a Tester agent → writes comprehensive tests
-5. Spawns a Documentation agent → generates API docs
-6. Stores patterns in memory → "Always use bcrypt for passwords"
-
-Next time: The memory helps agents make better decisions automatically
+1. Coder writes the endpoint
+2. Tester creates and runs focused tests
+3. Adversarial tries to break authentication and error paths
+4. Coder fixes concrete findings
+5. Reviewer gates the final patch
+6. Memory stores the project pattern for future work
 ```
+
+---
+
+## Who should use aistack
+
+- Claude Code users who want local multi-agent coding workflows.
+- TypeScript/Node teams that want coder, tester, reviewer, and adversarial agents coordinating through MCP/API.
+- Teams that want review loops, persistent SQLite memory, consensus gates, drift detection, and resource monitoring without adopting a hosted agent platform.
+
+## Who should NOT use aistack
+
+- Python-first teams that want LangGraph/CrewAI-style ecosystems.
+- Teams that need hosted multi-tenancy or horizontally distributed orchestration today.
+- Teams that require production OpenTelemetry tracing, sandboxed execution, or long-lived background runners as hard requirements today.
 
 ---
 
@@ -475,29 +495,8 @@ Create `aistack.config.json` in your project root:
 
 ### Example 1: Code Generation with Review
 
-**Via Claude Code (MCP)**:
-```
-In Claude Code, just ask:
-"Use aistack to generate a REST API for user authentication with adversarial review"
-
-aistack will:
-1. Spawn a coder agent to write the API
-2. Spawn an adversarial agent to find vulnerabilities
-3. Fix issues iteratively (up to 3 rounds)
-4. Return production-ready code
-```
-
-**Via CLI**:
-```bash
-# Start adversarial review loop
-npx @blackms/aistack workflow run adversarial-review \
-  --task "Create REST API for user authentication"
-
-# Check the review status
-npx @blackms/aistack agent list
-```
-
 **Via TypeScript**:
+
 ```typescript
 import { createReviewLoop, getConfig } from '@blackms/aistack';
 
@@ -507,8 +506,32 @@ const result = await createReviewLoop(
   { maxIterations: 3 }
 );
 
-console.log(result.finalVerdict); // APPROVED
-console.log(result.currentCode);   // Production-ready code
+console.log(result.finalVerdict); // APPROVED or REJECTED
+console.log(result.currentCode);  // Reviewed code after the final iteration
+console.log(result.reviews);      // Concrete findings from each review round
+```
+
+**Via REST/web API**:
+
+```bash
+# Start the web server first:
+npx @blackms/aistack web start
+
+curl -X POST http://localhost:3001/api/v1/review-loops \
+  -H 'Content-Type: application/json' \
+  -d '{"codeInput":"Create REST API for user authentication","maxIterations":3}'
+```
+
+Review loops are not registered as MCP tools yet. Use MCP for agents, memory, tasks,
+identity, consensus, sessions, system status, and GitHub tools. Use TypeScript or
+REST/web APIs when you want a programmatic review loop, and DSL templates when
+you want a reusable workflow file.
+
+**Via DSL template**:
+
+```bash
+npx @blackms/aistack workflow run templates/workflows/adversarial-review.yaml \
+  --input='{"input":"Create REST API for user authentication"}'
 ```
 
 ### Example 2: Build Institutional Knowledge
@@ -588,12 +611,11 @@ In Claude Code, you can:
 "Search memory for authentication patterns"
 → Uses memory_search tool
 
-"Start an adversarial review of this function"
-→ Uses review_loop_start tool
-
 "List all active agents"
 → Uses agent_list tool
 ```
+
+Review loops are available through the TypeScript API (`createReviewLoop`) and REST/web API, not as MCP tools.
 
 ### Example 5: CLI Workflow
 
@@ -724,7 +746,7 @@ Then open http://localhost:3001 to:
 
 **Total: 46 MCP Tools**
 
-> **Note:** Review loop functionality is available via the programmatic API (`createReviewLoop`) and CLI, but not exposed as MCP tools.
+> **Note:** Review loop functionality is available via the programmatic API (`createReviewLoop`) and REST/web API, but not exposed as MCP tools.
 
 ---
 
@@ -794,7 +816,7 @@ const agentTypes = listAgentTypes();
 aistack/
 ├── src/
 │   ├── agents/          # 11 agent types with system prompts + identity service
-│   ├── mcp/             # MCP server + 41 tools
+│   ├── mcp/             # MCP server + 46 tools
 │   ├── memory/          # SQLite + FTS5 + vector search
 │   ├── tasks/           # Drift detection service
 │   ├── monitoring/      # Resource exhaustion, metrics, health

--- a/docs/API.md
+++ b/docs/API.md
@@ -1377,7 +1377,7 @@ Get repository information.
 
 ### Review Loop (Programmatic API)
 
-> **Note:** Review loop functionality is available via the programmatic API (`createReviewLoop`) and CLI (`workflow run adversarial-review`), but not exposed as MCP tools. Use the TypeScript SDK for full review loop capabilities.
+> **Note:** Review loop functionality is available via the programmatic API (`createReviewLoop`) and REST/web API, but not exposed as MCP tools. Use the TypeScript SDK for full review loop capabilities.
 
 #### `review_loop_start` (Programmatic)
 

--- a/docs/HLD.md
+++ b/docs/HLD.md
@@ -295,7 +295,7 @@ sequenceDiagram
 
 **Total: 46 tools**
 
-> Note: Review loop functionality is available via programmatic API (`createReviewLoop`) and CLI, but not exposed as MCP tools.
+> Note: Review loop functionality is available via programmatic API (`createReviewLoop`) and REST/web API, but not exposed as MCP tools.
 
 ### 5.2 Provider Interface
 

--- a/docs/WORKFLOW_DSL.md
+++ b/docs/WORKFLOW_DSL.md
@@ -26,6 +26,33 @@ Add `--watch` to re-run on every file save:
 aistack workflow run my-flow.yaml --watch --input='{"input":"..."}'
 ```
 
+### M0 TDD workflow
+
+M0 issue work should use the agentic TDD template:
+
+```bash
+aistack workflow run templates/workflows/m0-agentic-tdd.yaml \
+  --input='{
+    "issue_id": "AIG-631",
+    "linear_url": "https://linear.app/...",
+    "github_context": "optional issue or PR links",
+    "input": "Rewrite README positioning with tests first"
+  }'
+```
+
+The template encodes the project workflow for M0 issues:
+
+1. `coordinator` scopes the issue into acceptance criteria.
+2. `researcher`, `architect`, and `tester` run discovery in parallel.
+3. `tester` writes red tests or docs guardrails before implementation.
+4. `coder` implements the smallest passing slice.
+5. `tester`, `adversarial`, and `reviewer` loop back to `implement` on `**VERDICT: REJECT**`.
+6. `documentation` and `devops` produce PR, Linear, and release handoff notes.
+
+Agents communicate through serialized step outputs such as `$steps.issue-discovery.output`,
+`$steps.red-tests.output`, and `$steps.peer-review.output`. Direct message-bus communication
+is still reserved for imperative orchestration code.
+
 ---
 
 ## Document schema
@@ -38,8 +65,8 @@ description: One-line summary    # optional
 version: "1"                     # optional, defaults to "1"
 max_iterations: 30               # optional global safety cap on total step executions
 defaults:
-  timeout_ms: 60000              # optional, per-step default
-  session_id: my-session         # optional, propagated to agent spawner
+  timeout_ms: 60000              # optional runner metadata; core executor does not enforce it
+  session_id: my-session         # optional runner metadata
 steps:                           # required, at least one
   - id: step-id                  # optional, alphanumeric / _ / -
     agent: coder                 # required (XOR with `parallel`)
@@ -54,7 +81,7 @@ steps:                           # required, at least one
       goto: step-id
       max_retries: 1
       fail_after: true
-    timeout_ms: 30000            # optional override
+    timeout_ms: 30000            # optional runner metadata; core executor does not enforce it
   - id: fan-out                  # OR — parallel block (no `agent`)
     parallel:
       - agent: researcher

--- a/src/workflows/dsl/executor.ts
+++ b/src/workflows/dsl/executor.ts
@@ -340,6 +340,7 @@ async function executeStep(
       })
     );
     const results = await Promise.all(childPromises);
+    const failures = results.filter((r) => r.error);
     return {
       index,
       id: step.id,
@@ -347,6 +348,12 @@ async function executeStep(
       durationMs: Date.now() - start,
       retries: 0,
       parallelResults: results,
+      error:
+        failures.length > 0
+          ? `parallel child failed: ${failures
+              .map((r) => `${r.id ?? r.agent ?? r.index}: ${r.error}`)
+              .join('; ')}`
+          : undefined,
     };
   }
 

--- a/templates/workflows/m0-agentic-tdd.yaml
+++ b/templates/workflows/m0-agentic-tdd.yaml
@@ -1,0 +1,204 @@
+name: m0-agentic-tdd
+description: M0 issue delivery workflow with TDD, shared agent outputs, and iterative review.
+version: "1"
+max_iterations: 60
+
+steps:
+  - id: intake
+    name: Scope M0 issue
+    agent: coordinator
+    input: |
+      Coordinate one M0 delivery issue.
+
+      Issue id: $task.issue_id
+      Linear URL: $task.linear_url
+      GitHub context: $task.github_context
+      Task: $task.input
+
+      Produce a compact execution contract:
+      - acceptance criteria
+      - files likely to change
+      - tests required before implementation
+      - risks or external dependencies
+      - the first smallest deliverable slice
+
+  - id: issue-discovery
+    name: Parallel discovery
+    parallel:
+      - id: product-brief
+        agent: researcher
+        input: |
+          Read the issue contract and summarize the product outcome, user-facing copy,
+          and non-goals.
+
+          Contract:
+          $steps.intake.output
+
+      - id: technical-map
+        agent: architect
+        input: |
+          Read the issue contract and map the smallest code/docs surface that can satisfy it.
+          Name existing modules, tests, templates, and docs to reuse.
+
+          Contract:
+          $steps.intake.output
+
+      - id: test-brief
+        agent: tester
+        input: |
+          Read the issue contract and propose failing tests or guard scripts that prove
+          the acceptance criteria before production changes are made.
+
+          Contract:
+          $steps.intake.output
+
+  - id: test-plan
+    name: TDD plan
+    agent: tester
+    input: |
+      Merge the parallel discovery output into a red-first test plan.
+
+      Discovery:
+      $steps.issue-discovery.output
+
+      Previous handoff or rejection feedback:
+      $prev.output
+
+      Output:
+      - exact test files to add or update
+      - expected red failure before implementation
+      - commands to run for red and green checks
+      - review gates that must return **VERDICT: APPROVE**
+
+  - id: red-tests
+    name: Write failing tests first
+    agent: tester
+    input: |
+      Implement only the failing tests or documentation guardrails from this plan.
+      Do not implement production changes yet.
+
+      Plan:
+      $steps.test-plan.output
+
+      End with **VERDICT: APPROVE** only when the tests fail for the expected reason.
+      End with **VERDICT: REJECT** if the test shape is missing, too broad, or not runnable.
+    on_reject:
+      goto: test-plan
+      max_retries: 2
+      fail_after: true
+
+  - id: implement
+    name: Implement minimal slice
+    agent: coder
+    input: |
+      Implement the smallest change that makes the red tests pass and satisfies the issue.
+
+      Issue contract:
+      $steps.intake.output
+
+      Test plan:
+      $steps.test-plan.output
+
+      Red tests:
+      $steps.red-tests.output
+
+      Latest handoff or rejecting gate feedback:
+      $prev.output
+
+      Preserve unrelated user changes. Keep the patch scoped to the issue.
+
+  - id: verify
+    name: Run focused verification
+    agent: tester
+    input: |
+      Run the targeted checks from the test plan against the implementation.
+
+      Implementation summary:
+      $steps.implement.output
+
+      Red-test output:
+      $steps.red-tests.output
+
+      End with **VERDICT: APPROVE** if the checks pass.
+      End with **VERDICT: REJECT** and include exact failing commands if anything fails.
+    on_reject:
+      goto: implement
+      max_retries: 4
+      fail_after: true
+
+  - id: adversarial-review
+    name: Attack the implementation
+    agent: adversarial
+    input: |
+      Attack the implementation against the issue contract, tests, and known M0 risks.
+      Look for overclaims, stale docs, hidden CI failures, regressions, and missing edge cases.
+
+      Contract:
+      $steps.intake.output
+
+      Verification:
+      $steps.verify.output
+
+      Implementation:
+      $steps.implement.output
+
+      End with **VERDICT: APPROVE** only when no blocking issue remains.
+      End with **VERDICT: REJECT** and concrete fixes otherwise.
+    on_reject:
+      goto: implement
+      max_retries: 3
+      fail_after: true
+
+  - id: peer-review
+    name: Peer review gate
+    agent: reviewer
+    input: |
+      Review the final patch as a PR reviewer.
+
+      Contract:
+      $steps.intake.output
+
+      Tests:
+      $steps.verify.output
+
+      Adversarial review:
+      $steps.adversarial-review.output
+
+      End with **VERDICT: APPROVE** if this is ready for CI and human review.
+      End with **VERDICT: REJECT** with actionable findings otherwise.
+    on_reject:
+      goto: implement
+      max_retries: 2
+      fail_after: true
+
+  - id: docs-and-status
+    name: Update handoff notes
+    agent: documentation
+    input: |
+      Summarize the work for PR and Linear handoff.
+
+      Issue:
+      $steps.intake.output
+
+      Verification:
+      $steps.verify.output
+
+      Peer review:
+      $steps.peer-review.output
+
+      Include remaining risks and do not mark external issues complete unless CI is green.
+
+  - id: release-check
+    name: Final release check
+    agent: devops
+    input: |
+      Produce the final release checklist for this M0 slice.
+
+      Handoff:
+      $steps.docs-and-status.output
+
+      Include:
+      - commands already run
+      - commands still required
+      - branch, commit, and PR readiness
+      - Linear/GitHub follow-up state

--- a/tests/unit/readme-positioning.test.ts
+++ b/tests/unit/readme-positioning.test.ts
@@ -1,0 +1,54 @@
+/**
+ * README positioning guardrails for M0.
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readme = readFileSync(new URL('../../README.md', import.meta.url), 'utf8');
+const separatorIndex = readme.indexOf('---');
+const aboveFold = separatorIndex >= 0 ? readme.slice(0, separatorIndex) : readme;
+
+function words(value: string): string[] {
+  return value.trim().split(/\s+/).filter(Boolean);
+}
+
+describe('README M0 positioning', () => {
+  it('uses an outcome-driven hero tagline capped at 12 words', () => {
+    const tagline = readme.match(/^##\s+(.+)$/m)?.[1] ?? '';
+
+    expect(words(tagline).length).toBeGreaterThan(0);
+    expect(words(tagline).length).toBeLessThanOrEqual(12);
+    expect(tagline).toMatch(/adversarial layer/i);
+    expect(tagline).toMatch(/survives review/i);
+  });
+
+  it('shows three above-fold value pillars with real proof points', () => {
+    for (const pillar of [
+      'Adversarial code review',
+      'Local-first Claude Code orchestration',
+      'Governable autonomy',
+    ]) {
+      expect(aboveFold).toContain(pillar);
+    }
+
+    expect(aboveFold).toContain('createReviewLoop');
+    expect(aboveFold).toContain('46 MCP tools');
+    expect(aboveFold).toContain('consensus checkpoints');
+    expect(aboveFold).toContain('resource limits');
+  });
+
+  it('states who should and should not use aistack', () => {
+    expect(readme).toMatch(/^## Who should use aistack$/m);
+    expect(readme).toMatch(/^## Who should NOT use aistack$/m);
+  });
+
+  it('does not regress known documentation claims', () => {
+    expect(readme).not.toContain('41 tools');
+    expect(readme).toContain('not exposed as MCP tools');
+    expect(readme).toContain('REST/web API');
+    expect(readme).not.toContain('workflow run adversarial-review');
+    expect(readme).not.toContain('review_loop_start tool');
+    expect(readme).not.toContain('production-ready code');
+  });
+});

--- a/tests/unit/workflows/dsl/executor.test.ts
+++ b/tests/unit/workflows/dsl/executor.test.ts
@@ -284,6 +284,7 @@ describe('executor — parallel fail-fast abort', () => {
     const elapsed = Date.now() - start;
     expect(aborts).toContain('slow');
     expect(elapsed).toBeLessThan(2000); // Did not wait for the 5s timeout
+    expect(results[0].error).toContain('parallel child failed');
     expect(results[0].parallelResults?.some((r) => r.error?.includes('fast fail'))).toBe(true);
   });
 });

--- a/tests/unit/workflows/dsl/templates.test.ts
+++ b/tests/unit/workflows/dsl/templates.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Workflow DSL template guard tests.
+ */
+
+import { readFileSync } from 'node:fs';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  parseWorkflow,
+  runWorkflow,
+  WorkflowContext,
+  type RunStepHook,
+  type Step,
+  type StepResult,
+} from '../../../../src/workflows/dsl/index.js';
+
+const m0TemplateUrl = new URL('../../../../templates/workflows/m0-agentic-tdd.yaml', import.meta.url);
+
+function text(input: string | Record<string, unknown> | undefined): string {
+  if (input === undefined) return '';
+  return typeof input === 'string' ? input : JSON.stringify(input);
+}
+
+function flattenAgents(steps: Step[]): string[] {
+  return steps.flatMap((step) => {
+    if (step.parallel) return flattenAgents(step.parallel);
+    return step.agent ? [step.agent] : [];
+  });
+}
+
+function findTopLevelStep(steps: Step[], id: string): Step {
+  const step = steps.find((candidate) => candidate.id === id);
+  if (!step) throw new Error(`Missing step ${id}`);
+  return step;
+}
+
+async function drain(gen: AsyncGenerator<StepResult>): Promise<StepResult[]> {
+  const out: StepResult[] = [];
+  for await (const result of gen) out.push(result);
+  return out;
+}
+
+describe('M0 agentic TDD workflow template', () => {
+  it('codifies issue intake, red-first tests, implementation, and review loops', async () => {
+    const doc = await parseWorkflow(readFileSync(m0TemplateUrl, 'utf8'));
+
+    expect(doc.name).toBe('m0-agentic-tdd');
+    expect(doc.description).toMatch(/M0/i);
+    expect(doc.max_iterations).toBeGreaterThanOrEqual(40);
+
+    const agents = new Set(flattenAgents(doc.steps));
+    for (const agent of [
+      'coordinator',
+      'researcher',
+      'architect',
+      'tester',
+      'coder',
+      'adversarial',
+      'reviewer',
+      'documentation',
+    ]) {
+      expect(agents).toContain(agent);
+    }
+
+    const discovery = findTopLevelStep(doc.steps, 'issue-discovery');
+    expect(discovery.parallel).toHaveLength(3);
+
+    const redTests = findTopLevelStep(doc.steps, 'red-tests');
+    expect(redTests.agent).toBe('tester');
+    expect(text(redTests.input)).toMatch(/failing tests/i);
+    expect(redTests.on_reject?.goto).toBe('test-plan');
+
+    const implement = findTopLevelStep(doc.steps, 'implement');
+    expect(implement.agent).toBe('coder');
+    expect(text(implement.input)).toContain('$steps.red-tests.output');
+    expect(text(implement.input)).toContain('$prev.output');
+
+    const verify = findTopLevelStep(doc.steps, 'verify');
+    expect(verify.agent).toBe('tester');
+    expect(verify.on_reject?.goto).toBe('implement');
+    expect(verify.on_reject?.max_retries).toBeGreaterThanOrEqual(3);
+    expect(verify.on_reject?.fail_after).toBe(true);
+
+    const adversarial = findTopLevelStep(doc.steps, 'adversarial-review');
+    expect(adversarial.on_reject?.goto).toBe('implement');
+    expect(text(adversarial.input)).toContain('$steps.verify.output');
+
+    const peerReview = findTopLevelStep(doc.steps, 'peer-review');
+    expect(peerReview.on_reject?.goto).toBe('implement');
+
+    const docsAndStatus = findTopLevelStep(doc.steps, 'docs-and-status');
+    expect(docsAndStatus.agent).toBe('documentation');
+    expect(text(docsAndStatus.input)).toContain('$steps.peer-review.output');
+  });
+
+  it('loops failed verification and review back through implementation', async () => {
+    const doc = await parseWorkflow(readFileSync(m0TemplateUrl, 'utf8'));
+    let verifyCalls = 0;
+    let adversarialCalls = 0;
+    const implementInputs: string[] = [];
+
+    const runStep: RunStepHook = vi.fn(async ({ stepId, agent, input }) => {
+      if (stepId === 'implement') {
+        implementInputs.push(input);
+      }
+
+      if (stepId === 'verify') {
+        verifyCalls++;
+        return {
+          output: `verify-${verifyCalls}`,
+          verdict: verifyCalls === 1 ? 'REJECT' : 'APPROVE',
+        };
+      }
+
+      if (stepId === 'adversarial-review') {
+        adversarialCalls++;
+        return {
+          output: `adversarial-${adversarialCalls}`,
+          verdict: adversarialCalls === 1 ? 'REJECT' : 'APPROVE',
+        };
+      }
+
+      if (stepId === 'red-tests' || stepId === 'peer-review') {
+        return { output: `${stepId}-approved`, verdict: 'APPROVE' };
+      }
+
+      return { output: `${agent}:${stepId ?? 'parallel'}` };
+    });
+
+    const ctx = new WorkflowContext({
+      task: {
+        issue_id: 'AIG-631',
+        input: 'Rewrite README positioning with TDD workflow guardrails',
+      },
+      runStep,
+    });
+    const results = await drain(runWorkflow(doc, ctx));
+
+    expect(results.some((result) => result.error)).toBe(false);
+    expect(results.filter((result) => result.id === 'implement')).toHaveLength(3);
+    expect(results.filter((result) => result.id === 'verify')).toHaveLength(3);
+    expect(results.filter((result) => result.id === 'adversarial-review')).toHaveLength(2);
+    expect(implementInputs[1]).toContain('verify-1');
+    expect(implementInputs[2]).toContain('adversarial-1');
+    expect(results.at(-1)?.id).toBe('release-check');
+  });
+});


### PR DESCRIPTION
## Summary
- Add an M0 agentic TDD workflow template with intake, parallel discovery, red-first tests, implementation, adversarial review, peer review, and release handoff.
- Update README positioning for AIG-631 with a short outcome tagline, three proof-backed above-fold pillars, and who should/should not use aistack.
- Fix workflow DSL parallel fan-out error propagation so failed child steps fail the parent gate.
- Add guard tests for README claims and M0 workflow retry handoffs.

## Verification
- npm run test:unit
- npm run typecheck
- npm run lint
- npm run build
- npx vitest run --config vitest.integration.config.ts --reporter=dot

## Linear
Refs AIG-631. Related M0 workflow/process hardening for AIG-629 follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced M0 TDD agentic workflow template for iterative, verdict-gated delivery.
  * Improved parallel-step error reporting to surface aggregated child failures.

* **Documentation**
  * Rewrote README hero, positioning, examples, and proof grid; clarified programmatic and REST/web API usage and removed prior CLI snippets.
  * Expanded DSL quick start and workflow guidance; updated project/tooling counts and MCP tools note.

* **Tests**
  * Added README positioning validation and comprehensive workflow-template/unit tests; tightened parallel-failure assertions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blackms/aistack/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->