### PR TITLE
fix: restore README M0 positioning contract broken by #48 (main is red)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # aistack
 
+## The adversarial layer where AI code survives review
+
 ### A durable, governed control plane for Claude Code multi-agent work — built on top of the natives, not around them
 
 [![npm version](https://img.shields.io/npm/v/@blackms/aistack?style=for-the-badge&color=CB3837&logo=npm&logoColor=white)](https://www.npmjs.com/package/@blackms/aistack)
@@ -28,6 +30,12 @@ SSO (SAML/OIDC) + SCIM · Docker + Helm · A2A · Multi-tenancy · Federation (o
 ```
 
 </div>
+
+**Three pillars:**
+
+- **Adversarial code review** — a dedicated adversarial agent attacks the coder's output in a structured loop (`createReviewLoop`) until it survives review or is rejected; consensus checkpoints and per-agent resource limits keep autonomy governable.
+- **Local-first Claude Code orchestration** — runs as an NPM package on your machine: a stdio MCP server (46 MCP tools), SQLite memory, REST/web API, and a dashboard. No hosted control plane.
+- **Governable autonomy** — consensus checkpoints, a hash-chained audit log, and per-agent resource limits gate every high-risk step.
 
 ---
 
@@ -74,6 +82,18 @@ Where aistack adds value is in the gaps Claude Code **explicitly does not cover*
 If your workflow lives inside Claude Code and you want adversarial review, consensus governance, persistent state, and self-host deployment — without adopting a hosted agent platform — aistack is built for you. We stay honest about what is shipped today versus what is partial or on the roadmap; gaps are marked explicitly throughout this README.
 
 ---
+
+## Who should use aistack
+
+- You work inside Claude Code and want **adversarial review, consensus gating, durable state, and self-host deployment** without adopting a hosted agent platform.
+- You need orchestration state that **survives across sessions or machines** (checkpointer, federation) or **enterprise governance** (SSO/SCIM, hash-chained audit, multi-tenancy).
+- You want to run agents **on-prem or air-gapped** via Docker + Helm.
+
+## Who should NOT use aistack
+
+- You work **single-machine, single-session, single-repo**: native Claude Code (subagents, Agent Teams, Agent View, hooks, skills) is enough and often better — there is no reason to add aistack.
+- You want a managed SaaS control plane: aistack is local-first and self-hosted only.
+- You expect features still in development (guardrails wired by default, SWE-bench scores, JetBrains extension): see the partial / roadmap table below.
 
 ## 🚀 Quick Start
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Each feature below links to the real module that implements it. Status is labele
 A dedicated adversarial agent attacks the coder's output, iterating until `APPROVED`/`REJECTED` or `maxIterations` (default 3), with a concurrency semaphore.
 `src/coordination/review-loop.ts` · exposed via the TypeScript API (`createReviewLoop`) and REST/web routes.
 
-> **Note:** the review loop is intentionally **not** registered as an MCP tool. Use the TypeScript API, REST/web API, or a DSL workflow template.
+> **Note:** the review loop is intentionally not registered as an MCP tool. Use the TypeScript API, REST/web API, or a DSL workflow template.
 
 ### 🤝 Consensus checkpoints — *Stable*
 

--- a/tests/unit/readme-positioning.test.ts
+++ b/tests/unit/readme-positioning.test.ts
@@ -45,7 +45,7 @@ describe('README M0 positioning', () => {
 
   it('does not regress known documentation claims', () => {
     expect(readme).not.toContain('41 tools');
-    expect(readme).toContain('not exposed as MCP tools');
+    expect(readme).toContain('not registered as an MCP tool');
     expect(readme).toContain('REST/web API');
     expect(readme).not.toContain('workflow run adversarial-review');
     expect(readme).not.toContain('review_loop_start tool');


### PR DESCRIPTION
## Why

PR #48 redesigned the README and broke `tests/unit/readme-positioning.test.ts`, which enforces the M0 positioning contract. **`main` is currently red.** This restores it without losing the honest, fact-checked content from #48.

## Changes (2 files, +19/-1)

**README.md** — re-adds the structural elements the test asserts, as genuine positioning content:
- hero tagline (H2): *"The adversarial layer where AI code survives review"*
- an above-fold **Three pillars** block carrying the proof points: `createReviewLoop`, `46 MCP tools`, `consensus checkpoints`, `resource limits`, plus the pillar names (Adversarial code review / Local-first Claude Code orchestration / Governable autonomy)
- **Who should use aistack** / **Who should NOT use aistack** sections

**tests/unit/readme-positioning.test.ts** — aligns one assertion to the current, more accurate wording (`not registered as an MCP tool`), since the review loop is intentionally not an MCP tool.

## Verification

All assertions in `readme-positioning.test.ts` were checked deterministically against the edited files (tagline = 8 words with both required phrases; all 7 above-fold proof substrings present before the first `---`; both Who-should headings anchored; no regressed claims). Final green is the CI on this PR.

No code/behavior change. Docs + test only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README with new positioning and an “adversarial layer” hero tagline.
  * Added a “Three pillars” section describing adversarial review, local-first orchestration, and governable autonomy.
  * Added “Who should use / Who should NOT use” guidance and clarified the review loop is not registered as an MCP tool.

* **Tests**
  * Adjusted a unit test to match the updated README wording about MCP tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->