### PR TITLE
[AIG-854] De-flake consensus expiry test with injectable clock/fake timers + CI repeat guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,38 @@ jobs:
       - name: Run tests
         run: npm test
 
+  # Dedicated guard against time-based flakiness in the consensus expiry
+  # tests (see AIG-854). Runs only the consensus suite, repeated 50x, so it
+  # stays fast while proving the tests are deterministic. Does NOT slow down
+  # the full test suite.
+  consensus-flake-guard:
+    name: Consensus Flake Guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # vitest 2.x exposes `repeats` only as a per-test option, not a CLI flag,
+      # so we loop the run 50x at the shell level. The whole loop fails fast if
+      # any single run fails (set -e + explicit exit on non-zero).
+      - name: Repeat consensus tests (50x)
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 50); do
+            echo "::group::consensus run $i/50"
+            npx vitest run tests/unit/consensus-service.test.ts
+            echo "::endgroup::"
+          done
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/tests/unit/consensus-service.test.ts
+++ b/tests/unit/consensus-service.test.ts
@@ -2,7 +2,7 @@
  * Consensus Service tests
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -399,26 +399,45 @@ describe('ConsensusService', () => {
   });
 
   describe('expireCheckpoints', () => {
+    // These tests are time-sensitive: checkpoint expiry compares the stored
+    // `expires_at` against the current time in both the service
+    // (`new Date()` in submitDecision) and the store (`Date.now()` in
+    // expireOldCheckpoints/createConsensusCheckpoint). Relying on the real
+    // wall-clock made them flaky (a slow CI runner could let the timeout
+    // elapse between create and approve). Fake timers freeze the clock so the
+    // create -> approve -> expire sequence is fully deterministic, and we
+    // advance time explicitly to cross the expiry boundary.
+    const FIXED_NOW = new Date('2026-01-01T00:00:00.000Z');
+    const TIMEOUT_MS = 300000;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(FIXED_NOW);
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('should expire old checkpoints', () => {
       store = new SQLiteStore(join(tmpDir, 'test.db'));
       const service = new ConsensusService(
         store,
         createConfig({
           consensusEnabled: true,
-          timeout: 300000,
+          timeout: TIMEOUT_MS,
         })
       );
 
-      // Create checkpoint that will expire immediately
+      // Create a pending checkpoint (expires_at = FIXED_NOW + TIMEOUT_MS).
       const checkpoint = service.createCheckpoint({
         taskId: 'task-1',
         proposedSubtasks: [],
         riskLevel: 'high',
       });
 
-      store.db
-        .prepare('UPDATE consensus_checkpoints SET expires_at = ? WHERE id = ?')
-        .run(Date.now() - 1, checkpoint.id);
+      // Advance past the expiry boundary deterministically.
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + TIMEOUT_MS + 1));
 
       const expired = service.expireCheckpoints();
 
@@ -434,7 +453,7 @@ describe('ConsensusService', () => {
         store,
         createConfig({
           consensusEnabled: true,
-          timeout: 300000,
+          timeout: TIMEOUT_MS,
         })
       );
 
@@ -444,12 +463,14 @@ describe('ConsensusService', () => {
         riskLevel: 'high',
       });
 
-      // Approve before expiration
+      // Approve while the checkpoint is still within its timeout window.
+      // With frozen time this is guaranteed (FIXED_NOW < FIXED_NOW + TIMEOUT_MS).
       const approval = service.approveCheckpoint(checkpoint.id, 'reviewer-1');
       expect(approval.success).toBe(true);
-      store.db
-        .prepare('UPDATE consensus_checkpoints SET expires_at = ? WHERE id = ?')
-        .run(Date.now() - 1, checkpoint.id);
+
+      // Advance past the expiry boundary; the checkpoint is already approved,
+      // so the expiry sweep (which only touches pending checkpoints) must skip it.
+      vi.setSystemTime(new Date(FIXED_NOW.getTime() + TIMEOUT_MS + 1));
 
       const expired = service.expireCheckpoints();
 


### PR DESCRIPTION
## Cosa cambia

Fix della flakiness time-based nei test `expireCheckpoints` di `tests/unit/consensus-service.test.ts` + nuovo guard CI.

### 1. Determinismo del tempo (fake timers)
I due test `expireCheckpoints` dipendevano dal **wall-clock reale**:
- lo store calcola la scadenza con `Date.now()` (`createConsensusCheckpoint`, `expireOldCheckpoints`)
- il service confronta `new Date() > checkpoint.expiresAt` in `submitDecision`

Su un runner CI lento il timeout poteva trascorrere tra `createCheckpoint` e `approveCheckpoint`, facendo finire un checkpoint approvato in stato `expired` (`AssertionError: expected 'expired' to be 'approved'`, gia osservato 1 volta nel job `coverage`).

**Fix:** congelo il tempo con `vi.useFakeTimers()` + `vi.setSystemTime()` attorno a entrambi i test e avanzo il clock esplicitamente per superare la soglia di scadenza. I fake timers di vitest intercettano sia `Date.now()` (store) sia `new Date()` (service), quindi l'intera sequenza create -> approve -> expire diventa deterministica. Sostituiti gli `UPDATE ... SET expires_at = Date.now() - 1` (fonte della corsa) con avanzamenti di tempo controllati.

> Scelta fake timers vs clock iniettabile: il tempo e letto direttamente in **due** classi (service + store). Iniettare un clock attraverso entrambe sarebbe un refactor invasivo della logica di business; i fake timers ottengono lo stesso determinismo toccando solo il test, rispettando il vincolo "non alterare la logica di business".

### 2. Guard CI permanente (repeat 50x)
Nuovo job `consensus-flake-guard` in `.github/workflows/ci.yml` che esegue **solo** il file consensus, ripetuto 50 volte, come guard contro future regressioni di flakiness. Veloce: gira solo `tests/unit/consensus-service.test.ts`, non l'intera suite, e non rallenta gli altri job.

> Nota: vitest 2.1.x **non** espone `--repeat`/`--repeats` come flag CLI (esiste solo come opzione per-test). Il repeat 50x e quindi realizzato con un loop shell `for` (`set -euo pipefail`, fail-fast alla prima run rossa).

## Scope file
- `tests/unit/consensus-service.test.ts` — fake timers sui test `expireCheckpoints`
- `.github/workflows/ci.yml` — nuovo job `consensus-flake-guard` (repeat 50x, solo consensus)

Nessuna modifica alla logica di business.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced consensus service test determinism and reliability.

* **Chores**
  * Added dedicated consensus flake detection to CI pipeline for improved test stability monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->