### PR TITLE
[AIG-867] Cost/budget governance + spend attribution su OTel/multitenancy

### DIFF
--- a/docs/GOVERNANCE.md
+++ b/docs/GOVERNANCE.md
@@ -1,0 +1,155 @@
+# Cost Governance (AIG-867)
+
+A cost-governance layer on top of the existing OpenTelemetry usage signal
+(`src/observability/tracing.ts`) and multi-tenancy (`src/multitenancy/`). It
+derives spend (tokens + estimated USD) from each LLM call, attributes it per
+tenant / workspace / project / agent-pattern, and enforces optional budget caps
+with a two-stage kill-switch (warn -> block).
+
+## Security default: opt-in, observe-only first
+
+The whole module is **disabled by default**:
+
+```jsonc
+// aistack.config.json (defaults shown)
+{
+  "governance": {
+    "enabled": false,          // master switch — module is a no-op when false
+    "enforce": {
+      "block": false,          // hard kill-switch — OFF by default (observe-only)
+      "warnThresholdPercent": 80
+    },
+    "window": "month"
+  }
+}
+```
+
+- `enabled: false` makes every entry point a no-op (mirrors guardrails AIG-868,
+  audit AIG-635, tracing — all off by default).
+- `enforce.block: false` means that even with governance **enabled** and a budget
+  defined, an over-budget call is **never blocked** — it is only accounted and a
+  `cost.budget.warn` / `cost.budget.block` audit event is emitted. This is the
+  recommended initial rollout (dry-run / observe-only).
+- Hard blocking at 100% requires **explicitly** setting `enforce.block: true`.
+
+This is intentional: a mis-configured budget can never take agents offline unless
+an operator opts into blocking.
+
+## Design decisions
+
+| Aspect | Choice |
+| --- | --- |
+| Unit of cost | Tokens (input/output separately); USD estimated via a configurable price-table. |
+| Pricing | Per `(provider, model)` glob, USD per 1M tokens. Unknown model -> **USD 0** (fail-open) but tokens are still aggregated + a warn is logged. Pricing is never a reason to block. |
+| Budget scope | Hierarchical: tenant/workspace + project + `agentPattern` (glob on agent type, e.g. `coder`, `review-*`, `*`). Most specific match wins; no budget = unlimited. |
+| Kill-switch | Two stages: `warn` at `warnThresholdPercent` (default 80%) -> `block` at 100%. Block throws `CostBudgetExceededError` **before** the LLM call (only when `enforce.block`). Warn/block audit events are idempotent per budget+window. |
+| Persistence | Append-only `cost_ledger` table on the shared SQLite store (`config.memory.path`), one row per LLM call, indexed by `(tenant, workspace, ts)` etc. Schema bootstrap is inline + idempotent. |
+| Window | Configurable: `day` (calendar), `week` (rolling 7d), `month` (calendar), `total` (all-time). Default `month`. |
+| Audit | Kill-switch events go to the existing hash-chained audit log via `audit(config, 'cost.budget.warn'|'cost.budget.block', payload)` (fire-and-forget, no-op when audit disabled). |
+| Interface | REST primary (`/api/v1/governance/*`) + a minimal `aistack governance` CLI. |
+
+## Spend attribution
+
+Spend is recorded at the single point where token usage is known — the agent
+spawner, right after the `aistack.llm.chat` span:
+
+```
+src/agents/spawner.ts  executeAgentInternal()
+  ├─ getGovernanceService(config)?.checkBudget({...})   // pre-call (may block)
+  ├─ traceAsync('aistack.llm.chat', ...)                // the LLM call
+  └─ getGovernanceService(config)?.recordSpend({...})   // post-call accounting
+```
+
+Tenant/workspace are read from the agent metadata folded in at spawn
+(`tenantId` / `workspaceId`, AIG-649). `project` is an optional free-form label
+passed via spawn metadata. In single-tenant mode the spend lands under the
+`__default__` bucket and tenant-scoped budgets do not apply.
+
+Recording **only** at this site avoids double counting from the review-loop /
+consensus spans (which do not carry `llm.usage.*`). An optional
+`GovernanceSpanProcessor` (`src/governance/span-adapter.ts`) is provided for
+deployments that wire an in-process OTel SpanProcessor; it must be **mutually
+exclusive** with the in-code path to avoid double counting, and is **not** wired
+by default.
+
+## Price table
+
+Defaults live in `src/governance/price-table.ts` (`DEFAULT_PRICE_TABLE`) and are
+approximate public list prices. Override per-deployment:
+
+```jsonc
+{
+  "governance": {
+    "enabled": true,
+    "priceTable": {
+      "anthropic": {
+        "claude-3-5-sonnet*": { "inputPerMTok": 3, "outputPerMTok": 15 }
+      }
+    }
+  }
+}
+```
+
+Overrides are merged per provider over the defaults, so you can replace a single
+model entry without restating the whole table. Prices **will drift** from real
+provider pricing — treat USD as an estimate, tokens as the source of truth.
+
+## Budgets
+
+```jsonc
+{
+  "governance": {
+    "enabled": true,
+    "enforce": { "block": true, "warnThresholdPercent": 80 },
+    "budgets": [
+      { "id": "org-monthly", "limitUsd": 1000, "window": "month" },
+      { "id": "tenant-a", "scope": { "tenant": "<tenant-id>" }, "limitUsd": 200 },
+      { "id": "coders", "scope": { "agentPattern": "coder" }, "limitTokens": 50000000 }
+    ]
+  }
+}
+```
+
+- `scope.tenant` / `scope.workspace` are **ids**, not slugs.
+- `agentPattern` is a glob against the concrete agent type.
+- Set `limitUsd` and/or `limitTokens`; whichever trips first wins.
+
+## REST endpoints
+
+All read-only (governance is configured via config, not the API). When disabled
+they return `{ "enabled": false, ... }` rather than an error.
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/api/v1/governance/status` | Module enabled/block state + ledger summary. |
+| GET | `/api/v1/governance/budgets` | Configured budgets. |
+| GET | `/api/v1/governance/spend?dimension=tenant\|workspace\|project\|agent&from&to&tenantId&workspaceId&project` | Grouped spend report. `from`/`to` accept epoch-ms or ISO-8601. |
+
+## CLI
+
+Modelled on `aistack audit`:
+
+```bash
+aistack governance status
+aistack governance budgets [--format table|json]
+aistack governance report --dimension tenant|workspace|project|agent \
+    [--from <ts>] [--to <ts>] [--format table|json]
+```
+
+## Limitations & follow-ups
+
+- **Soft cap, not an atomic quota**: between the pre-call check and the post-call
+  record, concurrent calls can slightly overrun a limit. Acceptable for a soft
+  budget; documented, not fixed here.
+- **Usage-bearing providers only**: spend is tracked only for providers that
+  return `chatResponse.usage` (Anthropic / OpenAI / Ollama). CLI providers
+  (ClaudeCode / Gemini / Codex) that don't populate usage are not tracked.
+- **Ledger growth**: `cost_ledger` is append-only. Retention / rollup is a
+  follow-up; rows are indexed by `(tenant, workspace, ts)` for now.
+
+## CI note
+
+These changes add unit tests under `tests/unit/governance/` and an integration
+test `tests/integration/governance.test.ts`. They run under the existing
+`vitest` suites — no new CI step is required, and `.github/workflows/ci.yml` is
+intentionally left untouched (changed in parallel by another branch).

--- a/src/agents/spawner.ts
+++ b/src/agents/spawner.ts
@@ -20,6 +20,7 @@ import {
 import { audit } from '../audit/index.js';
 import { saveCheckpointIfEnabled } from '../persistence/checkpointer.js';
 import { traceAsync, traceSync } from '../observability/index.js';
+import { getGovernanceService } from '../governance/index.js';
 
 const log = logger.child('spawner');
 
@@ -539,7 +540,30 @@ async function executeAgentInternal(
   updateAgentStatus(agentId, 'running');
   const startTime = Date.now();
 
+  // Cost governance (AIG-867): attribution metadata for budgets + spend.
+  // Folded into the agent metadata at spawn (tenantId/workspaceId); project is
+  // an optional free-form label passed via spawn metadata. All optional — falls
+  // back to default buckets when single-tenant.
+  const govTenantId =
+    typeof agent.metadata?.tenantId === 'string' ? agent.metadata.tenantId : undefined;
+  const govWorkspaceId =
+    typeof agent.metadata?.workspaceId === 'string'
+      ? agent.metadata.workspaceId
+      : undefined;
+  const govProject =
+    typeof agent.metadata?.project === 'string' ? agent.metadata.project : undefined;
+
   try {
+    // Pre-call budget check. No-op when governance is disabled. Throws
+    // CostBudgetExceededError BEFORE the LLM call only when enforce.block is on
+    // and the budget is at 100%; warn/observe modes never throw.
+    getGovernanceService(config)?.checkBudget({
+      tenantId: govTenantId,
+      workspaceId: govWorkspaceId,
+      project: govProject,
+      agentType: agent.type,
+    });
+
     log.info('Executing agent task', { agentId, type: agent.type, provider: providerName });
 
     const response = await traceAsync(config, 'aistack.llm.chat', {
@@ -583,6 +607,27 @@ async function executeAgentInternal(
         resourceService.evaluateAgent(agentId);
       } catch (error) {
         log.warn('Failed to record API call', { agentId, error: error instanceof Error ? error.message : 'Unknown error' });
+      }
+    }
+
+    // Cost governance (AIG-867): post-call accounting. PRIMARY attribution site
+    // (single point with llm.usage.*) — avoids double counting from review-loop
+    // / consensus spans. No-op when governance is disabled or usage is absent
+    // (CLI providers may not return usage). recordSpend never throws.
+    if (response.usage) {
+      try {
+        getGovernanceService(config)?.recordSpend({
+          inputTokens: response.usage.inputTokens,
+          outputTokens: response.usage.outputTokens,
+          provider: providerName,
+          model: response.model ?? options.model ?? 'unknown',
+          agentType: agent.type,
+          tenantId: govTenantId,
+          workspaceId: govWorkspaceId,
+          project: govProject,
+        });
+      } catch (error) {
+        log.warn('Failed to record spend', { agentId, error: error instanceof Error ? error.message : 'Unknown error' });
       }
     }
 

--- a/src/cli/commands/governance.ts
+++ b/src/cli/commands/governance.ts
@@ -1,0 +1,148 @@
+/**
+ * governance command — inspect cost/budget governance (AIG-867)
+ *
+ * Sub-commands:
+ *   - status   module enabled/block state + ledger summary
+ *   - budgets  list configured budgets
+ *   - report   grouped spend report by dimension (--dimension --from --to)
+ *
+ * Read-only: governance is configured via aistack.config.json, not the CLI.
+ * Modelled on src/cli/commands/audit.ts.
+ */
+
+import { Command } from 'commander';
+import { getConfig } from '../../utils/config.js';
+import { getGovernanceService } from '../../governance/index.js';
+import type { SpendDimension, SpendReportRow } from '../../governance/index.js';
+
+const VALID_DIMENSIONS: SpendDimension[] = ['tenant', 'workspace', 'project', 'agent'];
+
+function parseTs(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  if (/^\d+$/.test(raw)) return Number(raw);
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+function printTable(rows: SpendReportRow[], dimension: string): void {
+  const header = [dimension.toUpperCase(), 'CALLS', 'IN_TOK', 'OUT_TOK', 'TOTAL_TOK', 'USD'];
+  const data = rows.map((r) => [
+    r.key,
+    String(r.calls),
+    String(r.inputTokens),
+    String(r.outputTokens),
+    String(r.totalTokens),
+    r.usdCost.toFixed(4),
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...data.map((row) => row[i].length)),
+  );
+  const fmt = (cells: string[]): string =>
+    cells.map((c, i) => c.padEnd(widths[i])).join('  ');
+  console.log(fmt(header));
+  console.log(widths.map((w) => '-'.repeat(w)).join('  '));
+  for (const row of data) console.log(fmt(row));
+}
+
+export function createGovernanceCommand(): Command {
+  const command = new Command('governance').description(
+    'Inspect cost/budget governance (spend reports, budgets, status)',
+  );
+
+  command
+    .command('status')
+    .description('Show governance status and ledger summary')
+    .action(() => {
+      const config = getConfig();
+      const service = getGovernanceService(config);
+      if (!service) {
+        console.log('Cost governance: disabled (config.governance.enabled = false)');
+        return;
+      }
+      const s = service.getStatus();
+      console.log(`Cost governance: ${s.enabled ? 'enabled' : 'disabled'}`);
+      console.log(`Block (kill-switch): ${s.blockEnabled ? 'ON' : 'off (observe-only)'}`);
+      console.log(`Warn threshold:      ${s.warnThresholdPercent}%`);
+      console.log(`Default window:      ${s.window}`);
+      console.log(`Budgets configured:  ${s.budgets}`);
+      console.log(`Ledger rows:         ${s.ledgerRows}`);
+    });
+
+  command
+    .command('budgets')
+    .description('List configured budgets')
+    .option('-f, --format <fmt>', 'Output format: table | json', 'table')
+    .action((options: { format: string }) => {
+      const config = getConfig();
+      const service = getGovernanceService(config);
+      const budgets = service?.getBudgets() ?? [];
+      if (options.format.toLowerCase() === 'json') {
+        console.log(JSON.stringify(budgets, null, 2));
+        return;
+      }
+      if (budgets.length === 0) {
+        console.log('No budgets configured (unlimited).');
+        return;
+      }
+      for (const b of budgets) {
+        const scope = b.scope ?? {};
+        const scopeStr =
+          Object.entries(scope)
+            .map(([k, v]) => `${k}=${v}`)
+            .join(', ') || '(global)';
+        const limit = [
+          b.limitUsd !== undefined ? `$${b.limitUsd}` : null,
+          b.limitTokens !== undefined ? `${b.limitTokens} tok` : null,
+        ]
+          .filter(Boolean)
+          .join(' / ');
+        console.log(`- ${b.id ?? '(unnamed)'} [${scopeStr}] limit=${limit} window=${b.window ?? 'default'}`);
+      }
+    });
+
+  command
+    .command('report')
+    .description('Grouped spend report by dimension')
+    .option('-d, --dimension <dim>', 'tenant | workspace | project | agent', 'tenant')
+    .option('--from <ts>', 'Lower bound (epoch ms or ISO-8601)')
+    .option('--to <ts>', 'Upper bound (epoch ms or ISO-8601)')
+    .option('-f, --format <fmt>', 'Output format: table | json', 'table')
+    .action((options: { dimension: string; from?: string; to?: string; format: string }) => {
+      const config = getConfig();
+      const service = getGovernanceService(config);
+      if (!service) {
+        console.error('Cost governance is disabled. Enable with config.governance.enabled = true.');
+        process.exit(1);
+      }
+
+      const dim = options.dimension as SpendDimension;
+      if (!VALID_DIMENSIONS.includes(dim)) {
+        console.error(`Invalid dimension "${options.dimension}" (use ${VALID_DIMENSIONS.join('|')})`);
+        process.exit(1);
+      }
+
+      const report = service.getReport({
+        dimension: dim,
+        from: parseTs(options.from),
+        to: parseTs(options.to),
+      });
+
+      if (options.format.toLowerCase() === 'json') {
+        console.log(JSON.stringify(report, null, 2));
+        return;
+      }
+
+      if (report.rows.length === 0) {
+        console.log('No spend recorded for the selected window.');
+        return;
+      }
+      printTable(report.rows, dim);
+      console.log('');
+      console.log(
+        `TOTAL: ${report.totals.calls} calls, ${report.totals.totalTokens} tokens, ` +
+          `$${report.totals.usdCost.toFixed(4)}`,
+      );
+    });
+
+  return command;
+}

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -18,6 +18,7 @@ export { createDaemonCommand } from './daemon.js';
 export { createWatchCommand } from './watch.js';
 export { createRunCommand } from './run.js';
 export { createAuditCommand } from './audit.js';
+export { createGovernanceCommand } from './governance.js';
 export { createExportAgentsCommand } from './export-agents.js';
 export { createAgentPortableCommand } from './agent-portable.js';
 export { createFederationCommand } from './federation.js';

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -22,6 +22,7 @@ import {
   createWatchCommand,
   createRunCommand,
   createAuditCommand,
+  createGovernanceCommand,
   createExportAgentsCommand,
   createAgentPortableCommand,
   createFederationCommand,
@@ -66,6 +67,7 @@ async function main(): Promise<void> {
   program.addCommand(createWatchCommand());
   program.addCommand(createRunCommand());
   program.addCommand(createAuditCommand());
+  program.addCommand(createGovernanceCommand());
   program.addCommand(createExportAgentsCommand());
   program.addCommand(createAgentPortableCommand());
   program.addCommand(createFederationCommand());

--- a/src/governance/aggregator.ts
+++ b/src/governance/aggregator.ts
@@ -1,0 +1,254 @@
+/**
+ * CostAggregator (AIG-867).
+ *
+ * Persists one append-only row per LLM call into `cost_ledger` and answers
+ * grouped spend queries by dimension. Uses the shared SQLite database (the same
+ * file `getMemoryManager(config).getStore()` opens) so reports survive process
+ * restarts and can be inspected with standard SQLite tooling.
+ *
+ * Schema bootstrap is inline + idempotent (mirrors TenantService) so unit tests
+ * and REPL usage work without running a migration file first.
+ */
+
+import type Database from 'better-sqlite3';
+import { logger } from '../utils/logger.js';
+import {
+  DEFAULT_BUCKET,
+  type SpendDimension,
+  type SpendQuery,
+  type SpendRecord,
+  type SpendReport,
+  type SpendReportRow,
+} from './types.js';
+
+const log = logger.child('governance:aggregator');
+
+interface LedgerAggRow {
+  key: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  usd_cost: number;
+  calls: number;
+}
+
+/** Column the GROUP BY uses for each report dimension. */
+const DIMENSION_COLUMN: Record<SpendDimension, string> = {
+  tenant: 'tenant_id',
+  workspace: 'workspace_id',
+  project: 'project',
+  agent: 'agent_type',
+};
+
+export class CostAggregator {
+  private db: Database.Database;
+
+  constructor(db: Database.Database) {
+    this.db = db;
+    this.ensureSchema();
+  }
+
+  private ensureSchema(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS cost_ledger (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        ts INTEGER NOT NULL,
+        tenant_id TEXT NOT NULL,
+        workspace_id TEXT,
+        project TEXT NOT NULL,
+        agent_type TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER NOT NULL,
+        output_tokens INTEGER NOT NULL,
+        usd_cost REAL NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS idx_cost_ledger_ts ON cost_ledger(ts);
+      CREATE INDEX IF NOT EXISTS idx_cost_ledger_tenant_ts
+        ON cost_ledger(tenant_id, ts);
+      CREATE INDEX IF NOT EXISTS idx_cost_ledger_tenant_ws_ts
+        ON cost_ledger(tenant_id, workspace_id, ts);
+      CREATE INDEX IF NOT EXISTS idx_cost_ledger_project_ts
+        ON cost_ledger(project, ts);
+      CREATE INDEX IF NOT EXISTS idx_cost_ledger_agent_ts
+        ON cost_ledger(agent_type, ts);
+    `);
+  }
+
+  /**
+   * Append a spend record. Caller is expected to have already computed
+   * `usdCost`; if absent it is stored as 0 (tokens are always preserved).
+   */
+  recordSpend(record: SpendRecord): void {
+    const ts = record.ts ?? Date.now();
+    try {
+      this.db
+        .prepare(
+          `INSERT INTO cost_ledger
+             (ts, tenant_id, workspace_id, project, agent_type,
+              provider, model, input_tokens, output_tokens, usd_cost)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          ts,
+          record.tenantId ?? DEFAULT_BUCKET,
+          record.workspaceId ?? null,
+          record.project ?? DEFAULT_BUCKET,
+          record.agentType ?? DEFAULT_BUCKET,
+          record.provider,
+          record.model,
+          record.inputTokens,
+          record.outputTokens,
+          record.usdCost ?? 0,
+        );
+    } catch (err) {
+      // Accounting must never break the caller's flow.
+      log.warn('Failed to record spend', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Sum tokens and USD over a window, optionally filtered by scope. Used by the
+   * enforcer to compute current spend against a budget.
+   */
+  sumSpend(filters: {
+    from?: number;
+    to?: number;
+    tenantId?: string;
+    workspaceId?: string;
+    project?: string;
+    agentType?: string;
+  }): { inputTokens: number; outputTokens: number; usdCost: number; calls: number } {
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (filters.from !== undefined) {
+      where.push('ts >= ?');
+      params.push(filters.from);
+    }
+    if (filters.to !== undefined) {
+      where.push('ts <= ?');
+      params.push(filters.to);
+    }
+    if (filters.tenantId !== undefined) {
+      where.push('tenant_id = ?');
+      params.push(filters.tenantId);
+    }
+    if (filters.workspaceId !== undefined) {
+      where.push('workspace_id = ?');
+      params.push(filters.workspaceId);
+    }
+    if (filters.project !== undefined) {
+      where.push('project = ?');
+      params.push(filters.project);
+    }
+    if (filters.agentType !== undefined) {
+      where.push('agent_type = ?');
+      params.push(filters.agentType);
+    }
+    const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    const row = this.db
+      .prepare(
+        `SELECT
+           COALESCE(SUM(input_tokens), 0) AS input_tokens,
+           COALESCE(SUM(output_tokens), 0) AS output_tokens,
+           COALESCE(SUM(usd_cost), 0) AS usd_cost,
+           COUNT(*) AS calls
+         FROM cost_ledger ${clause}`,
+      )
+      .get(...params) as {
+        input_tokens: number;
+        output_tokens: number;
+        usd_cost: number;
+        calls: number;
+      };
+    return {
+      inputTokens: row.input_tokens,
+      outputTokens: row.output_tokens,
+      usdCost: row.usd_cost,
+      calls: row.calls,
+    };
+  }
+
+  /**
+   * Grouped spend report by the requested dimension. Rows are ordered by USD
+   * cost descending so the biggest spenders surface first.
+   */
+  querySpend(query: SpendQuery): SpendReport {
+    const column = DIMENSION_COLUMN[query.dimension];
+    const where: string[] = [];
+    const params: unknown[] = [];
+    if (query.from !== undefined) {
+      where.push('ts >= ?');
+      params.push(query.from);
+    }
+    if (query.to !== undefined) {
+      where.push('ts <= ?');
+      params.push(query.to);
+    }
+    if (query.tenantId !== undefined) {
+      where.push('tenant_id = ?');
+      params.push(query.tenantId);
+    }
+    if (query.workspaceId !== undefined) {
+      where.push('workspace_id = ?');
+      params.push(query.workspaceId);
+    }
+    if (query.project !== undefined) {
+      where.push('project = ?');
+      params.push(query.project);
+    }
+    const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+    const rows = this.db
+      .prepare(
+        `SELECT
+           ${column} AS key,
+           COALESCE(SUM(input_tokens), 0) AS input_tokens,
+           COALESCE(SUM(output_tokens), 0) AS output_tokens,
+           COALESCE(SUM(usd_cost), 0) AS usd_cost,
+           COUNT(*) AS calls
+         FROM cost_ledger ${clause}
+         GROUP BY ${column}
+         ORDER BY usd_cost DESC, calls DESC`,
+      )
+      .all(...params) as LedgerAggRow[];
+
+    const reportRows: SpendReportRow[] = rows.map((r) => ({
+      key: r.key ?? DEFAULT_BUCKET,
+      inputTokens: r.input_tokens,
+      outputTokens: r.output_tokens,
+      totalTokens: r.input_tokens + r.output_tokens,
+      usdCost: r.usd_cost,
+      calls: r.calls,
+    }));
+
+    const totals = reportRows.reduce(
+      (acc, r) => {
+        acc.inputTokens += r.inputTokens;
+        acc.outputTokens += r.outputTokens;
+        acc.totalTokens += r.totalTokens;
+        acc.usdCost += r.usdCost;
+        acc.calls += r.calls;
+        return acc;
+      },
+      { inputTokens: 0, outputTokens: 0, totalTokens: 0, usdCost: 0, calls: 0 },
+    );
+
+    return {
+      dimension: query.dimension,
+      from: query.from,
+      to: query.to,
+      rows: reportRows,
+      totals,
+    };
+  }
+
+  /** Total rows in the ledger (for status). */
+  count(): number {
+    const row = this.db
+      .prepare('SELECT COUNT(*) AS n FROM cost_ledger')
+      .get() as { n: number };
+    return row.n;
+  }
+}

--- a/src/governance/enforcer.ts
+++ b/src/governance/enforcer.ts
@@ -1,0 +1,242 @@
+/**
+ * BudgetEnforcer (AIG-867).
+ *
+ * Resolves the effective budget for a (tenant, workspace, project, agent) tuple,
+ * compares current window spend against it, and produces an `ok | warn | block`
+ * state. Emits `cost.budget.warn` / `cost.budget.block` audit events (idempotent
+ * per budget+window) and, only when `enforce.block` is enabled, signals that the
+ * caller should throw a CostBudgetExceededError.
+ *
+ * SECURITY DEFAULT: `enforce.block` is false unless explicitly enabled, so the
+ * enforcer is observe-only (accounting + warn) out of the box.
+ *
+ * NOTE: enforcement is a soft cap, not an atomic quota — concurrent calls
+ * between checkBudget() and recordSpend() can slightly overrun the limit.
+ */
+
+import type { AgentStackConfig } from '../types.js';
+import { audit } from '../audit/index.js';
+import { logger } from '../utils/logger.js';
+import type { CostAggregator } from './aggregator.js';
+import {
+  DEFAULT_BUCKET,
+  type BudgetCheckContext,
+  type BudgetEvaluation,
+  type BudgetWindow,
+  type CostBudget,
+  type GovernanceConfig,
+} from './types.js';
+
+const log = logger.child('governance:enforcer');
+
+const DEFAULT_WARN_PERCENT = 80;
+
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+/**
+ * Compute the inclusive lower bound (epoch millis) of the current budget window.
+ * `total` returns 0 (all time). Calendar-aligned for day/month, rolling 7d for
+ * week to keep it simple and timezone-independent enough for a soft cap.
+ */
+export function windowStart(window: BudgetWindow, now: number = Date.now()): number {
+  if (window === 'total') return 0;
+  const d = new Date(now);
+  if (window === 'day') {
+    return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  }
+  if (window === 'month') {
+    return new Date(d.getFullYear(), d.getMonth(), 1).getTime();
+  }
+  // week: rolling 7 days
+  return now - 7 * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Score how specifically a budget scope matches the given context. Higher score
+ * = more specific. Returns null when the scope explicitly conflicts with the
+ * context (e.g. budget targets tenant A but context is tenant B).
+ */
+function scopeScore(budget: CostBudget, ctx: BudgetCheckContext): number | null {
+  const scope = budget.scope ?? {};
+  let score = 0;
+
+  if (scope.tenant !== undefined) {
+    if ((ctx.tenantId ?? DEFAULT_BUCKET) !== scope.tenant) return null;
+    score += 8;
+  }
+  if (scope.workspace !== undefined) {
+    if ((ctx.workspaceId ?? '') !== scope.workspace) return null;
+    score += 4;
+  }
+  if (scope.project !== undefined) {
+    if ((ctx.project ?? DEFAULT_BUCKET) !== scope.project) return null;
+    score += 2;
+  }
+  if (scope.agentPattern !== undefined) {
+    const agentType = ctx.agentType ?? DEFAULT_BUCKET;
+    if (!globToRegExp(scope.agentPattern).test(agentType)) return null;
+    // Exact (non-wildcard) patterns are more specific than globs.
+    score += scope.agentPattern.includes('*') ? 1 : 3;
+  }
+  return score;
+}
+
+export class BudgetEnforcer {
+  private config: AgentStackConfig;
+  private governance: GovernanceConfig;
+  private aggregator: CostAggregator;
+  /** Tracks which (budgetKey:windowStart:stage) events were already emitted. */
+  private emitted = new Set<string>();
+
+  constructor(
+    config: AgentStackConfig,
+    governance: GovernanceConfig,
+    aggregator: CostAggregator,
+  ) {
+    this.config = config;
+    this.governance = governance;
+    this.aggregator = aggregator;
+  }
+
+  /**
+   * Select the most specific budget that matches the context. Budgets that
+   * don't match the context's tenant/workspace/etc are skipped.
+   */
+  resolveBudget(ctx: BudgetCheckContext): CostBudget | undefined {
+    const budgets = this.governance.budgets ?? [];
+    let best: { budget: CostBudget; score: number } | undefined;
+    for (const budget of budgets) {
+      const score = scopeScore(budget, ctx);
+      if (score === null) continue;
+      if (!best || score > best.score) {
+        best = { budget, score };
+      }
+    }
+    return best?.budget;
+  }
+
+  private budgetKey(budget: CostBudget): string {
+    return (
+      budget.id ??
+      JSON.stringify({
+        s: budget.scope ?? {},
+        u: budget.limitUsd ?? null,
+        t: budget.limitTokens ?? null,
+      })
+    );
+  }
+
+  /**
+   * Evaluate the budget for the given context. Pure read + audit side-effect;
+   * never throws. Returns the enforcement state.
+   */
+  evaluate(ctx: BudgetCheckContext): BudgetEvaluation {
+    const budget = this.resolveBudget(ctx);
+    if (!budget) {
+      return { state: 'ok', currentUsd: 0, currentTokens: 0, percent: 0 };
+    }
+
+    const window = budget.window ?? this.governance.window ?? 'month';
+    const from = windowStart(window);
+
+    // Sum spend within the budget's scope. Only filter by scope fields that the
+    // budget actually constrains, so a tenant-only budget aggregates across all
+    // its workspaces/projects.
+    const scope = budget.scope ?? {};
+    const sum = this.aggregator.sumSpend({
+      from,
+      tenantId: scope.tenant,
+      workspaceId: scope.workspace,
+      project: scope.project,
+      // agentPattern is a glob; can't push into SQL equality, so it is left to
+      // the (rare) budget that scopes by exact agent type only.
+      agentType:
+        scope.agentPattern && !scope.agentPattern.includes('*')
+          ? scope.agentPattern
+          : undefined,
+    });
+
+    const currentTokens = sum.inputTokens + sum.outputTokens;
+    const currentUsd = sum.usdCost;
+
+    // Determine the percentage against whichever limit is the binding one.
+    let percent = 0;
+    if (budget.limitUsd && budget.limitUsd > 0) {
+      percent = Math.max(percent, (currentUsd / budget.limitUsd) * 100);
+    }
+    if (budget.limitTokens && budget.limitTokens > 0) {
+      percent = Math.max(percent, (currentTokens / budget.limitTokens) * 100);
+    }
+
+    const warnPercent =
+      this.governance.enforce?.warnThresholdPercent ?? DEFAULT_WARN_PERCENT;
+
+    let state: BudgetEvaluation['state'] = 'ok';
+    if (percent >= 100) {
+      state = 'block';
+    } else if (warnPercent > 0 && percent >= warnPercent) {
+      state = 'warn';
+    }
+
+    if (state !== 'ok') {
+      this.emitOnce(budget, window, from, state, {
+        percent: Math.round(percent * 100) / 100,
+        currentUsd,
+        currentTokens,
+        limitUsd: budget.limitUsd ?? null,
+        limitTokens: budget.limitTokens ?? null,
+        tenantId: ctx.tenantId ?? DEFAULT_BUCKET,
+        workspaceId: ctx.workspaceId ?? null,
+        project: ctx.project ?? DEFAULT_BUCKET,
+        agentType: ctx.agentType ?? DEFAULT_BUCKET,
+        window,
+      });
+    }
+
+    return { state, budget, currentUsd, currentTokens, percent };
+  }
+
+  /**
+   * Emit a warn/block audit event at most once per (budget, window, stage). A
+   * block event is also emitted for higher stages even if a warn was already
+   * sent for the same window.
+   */
+  private emitOnce(
+    budget: CostBudget,
+    window: BudgetWindow,
+    from: number,
+    stage: 'warn' | 'block',
+    payload: Record<string, unknown>,
+  ): void {
+    const key = `${this.budgetKey(budget)}:${from}:${stage}`;
+    if (this.emitted.has(key)) return;
+    this.emitted.add(key);
+
+    const eventType = stage === 'block' ? 'cost.budget.block' : 'cost.budget.warn';
+    const enriched = { ...payload, budgetId: budget.id ?? null };
+
+    if (stage === 'block') {
+      log.warn('Budget block threshold reached', enriched);
+    } else {
+      log.warn('Budget warn threshold reached', enriched);
+    }
+    // Fire-and-forget; audit() is itself non-throwing and no-op when disabled.
+    audit(this.config, eventType, enriched);
+  }
+
+  /** Whether hard blocking is enabled. */
+  isBlockEnabled(): boolean {
+    return this.governance.enforce?.block === true;
+  }
+
+  /** Reset idempotency state (testing only). */
+  _resetEmitted(): void {
+    this.emitted.clear();
+  }
+}

--- a/src/governance/enforcer.ts
+++ b/src/governance/enforcer.ts
@@ -41,8 +41,9 @@ function globToRegExp(glob: string): RegExp {
 
 /**
  * Compute the inclusive lower bound (epoch millis) of the current budget window.
- * `total` returns 0 (all time). Calendar-aligned for day/month, rolling 7d for
- * week to keep it simple and timezone-independent enough for a soft cap.
+ * `total` returns 0 (all time). All bounded windows are calendar-aligned (using
+ * the same local-time basis as day/month) so the bound is stable within a window
+ * and audit dedup keys derived from it don't churn on every call.
  */
 export function windowStart(window: BudgetWindow, now: number = Date.now()): number {
   if (window === 'total') return 0;
@@ -53,8 +54,10 @@ export function windowStart(window: BudgetWindow, now: number = Date.now()): num
   if (window === 'month') {
     return new Date(d.getFullYear(), d.getMonth(), 1).getTime();
   }
-  // week: rolling 7 days
-  return now - 7 * 24 * 60 * 60 * 1000;
+  // week: start of the current ISO week (Monday) at 00:00 local time.
+  // getDay() is 0..6 with Sunday=0; shift so Monday is the first day.
+  const dayOfWeek = (d.getDay() + 6) % 7;
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate() - dayOfWeek).getTime();
 }
 
 /**

--- a/src/governance/index.ts
+++ b/src/governance/index.ts
@@ -1,0 +1,148 @@
+/**
+ * Cost governance module (AIG-867) — public facade.
+ *
+ * A cost-governance layer on top of the OTel usage signal + multitenancy:
+ *   - derives spend (tokens + estimated USD) from each LLM call,
+ *   - attributes it per tenant/workspace/project/agent-pattern,
+ *   - enforces optional budget caps with a warn -> block kill-switch,
+ *   - exposes spend reports via REST (`/api/v1/governance/*`) and a CLI.
+ *
+ * SECURITY DEFAULT: opt-in. `config.governance.enabled` defaults to false, and
+ * `enforce.block` defaults to false, so the module is a no-op until explicitly
+ * enabled and blocking is an additional explicit opt-in (observe-only first).
+ *
+ * Singleton lifecycle mirrors getAuditChain/getMemoryManager: a lazily created
+ * instance keyed off the shared SQLite store, with a reset hook for tests.
+ */
+
+import Database from 'better-sqlite3';
+import { dirname } from 'node:path';
+import { existsSync, mkdirSync } from 'node:fs';
+import type { AgentStackConfig } from '../types.js';
+import { logger } from '../utils/logger.js';
+import { GovernanceService } from './service.js';
+
+export { GovernanceService, CostBudgetExceededError } from './service.js';
+export type { RecordSpendInput } from './service.js';
+export { CostAggregator } from './aggregator.js';
+export { BudgetEnforcer, windowStart } from './enforcer.js';
+export {
+  DEFAULT_PRICE_TABLE,
+  resolvePrice,
+  estimateUsdCost,
+  mergePriceTable,
+} from './price-table.js';
+export type {
+  GovernanceConfig,
+  GovernanceEnforceConfig,
+  CostBudget,
+  CostBudgetScope,
+  BudgetWindow,
+  BudgetState,
+  BudgetEvaluation,
+  BudgetCheckContext,
+  ModelPrice,
+  PriceTable,
+  SpendDimension,
+  SpendRecord,
+  SpendReport,
+  SpendReportRow,
+  SpendQuery,
+} from './types.js';
+export { DEFAULT_BUCKET } from './types.js';
+
+const log = logger.child('governance');
+
+let instance: GovernanceService | null = null;
+let configured = false;
+let ownedDb: Database.Database | null = null;
+
+/**
+ * Open the shared SQLite DB. We open our own handle to the same file rather than
+ * reaching into MemoryManager so the module stays decoupled and usable from the
+ * CLI without booting the full memory manager. better-sqlite3 multi-connection
+ * to one WAL file is safe.
+ */
+function openDb(config: AgentStackConfig): Database.Database {
+  const path = config.memory.path;
+  const dir = dirname(path);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  const db = new Database(path);
+  db.pragma('journal_mode = WAL');
+  return db;
+}
+
+/**
+ * Initialise the governance service. Idempotent. Returns null when governance
+ * is disabled in config (the entire module is then a no-op). Safe to call
+ * eagerly at boot or lazily via getGovernanceService().
+ */
+export function initGovernance(config: AgentStackConfig): GovernanceService | null {
+  if (configured) return instance;
+  configured = true;
+
+  if (!config.governance?.enabled) {
+    instance = null;
+    return null;
+  }
+
+  try {
+    ownedDb = openDb(config);
+    instance = new GovernanceService(config, ownedDb);
+    const status = instance.getStatus();
+    log.info('Cost governance initialised', {
+      block: status.blockEnabled,
+      warnThresholdPercent: status.warnThresholdPercent,
+      budgets: status.budgets,
+    });
+  } catch (err) {
+    log.error('Failed to initialise cost governance — governance disabled', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    instance = null;
+  }
+  return instance;
+}
+
+/**
+ * Lazy singleton accessor. Returns the service or null when disabled. Call
+ * sites in the spawner use the null-safe `?.` so a disabled module costs
+ * nothing beyond a map lookup.
+ */
+export function getGovernanceService(
+  config: AgentStackConfig,
+): GovernanceService | null {
+  if (!configured) return initGovernance(config);
+  return instance;
+}
+
+/**
+ * Convenience wrapper for the post-call accounting site. Fire-and-forget,
+ * never throws. No-op when governance is disabled.
+ */
+export function recordSpend(
+  config: AgentStackConfig,
+  input: import('./service.js').RecordSpendInput,
+): void {
+  try {
+    getGovernanceService(config)?.recordSpend(input);
+  } catch (err) {
+    log.warn('recordSpend failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/** Reset the singleton (testing only). */
+export function resetGovernanceService(): void {
+  if (ownedDb) {
+    try {
+      ownedDb.close();
+    } catch {
+      // ignore
+    }
+  }
+  ownedDb = null;
+  instance = null;
+  configured = false;
+}

--- a/src/governance/index.ts
+++ b/src/governance/index.ts
@@ -21,6 +21,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import type { AgentStackConfig } from '../types.js';
 import { logger } from '../utils/logger.js';
 import { GovernanceService } from './service.js';
+import type { RecordSpendInput } from './service.js';
 
 export { GovernanceService, CostBudgetExceededError } from './service.js';
 export type { RecordSpendInput } from './service.js';
@@ -122,7 +123,7 @@ export function getGovernanceService(
  */
 export function recordSpend(
   config: AgentStackConfig,
-  input: import('./service.js').RecordSpendInput,
+  input: RecordSpendInput,
 ): void {
   try {
     getGovernanceService(config)?.recordSpend(input);

--- a/src/governance/price-table.ts
+++ b/src/governance/price-table.ts
@@ -1,0 +1,151 @@
+/**
+ * Price-table resolution (AIG-867).
+ *
+ * Maps a (provider, model) pair to a USD-per-million-token price so the
+ * aggregator can attach an estimated cost to each spend record. Resolution is
+ * fail-open: an unknown provider/model resolves to a zero price (tokens are
+ * still counted, USD is just 0) and logs a one-time-ish warning. Pricing is
+ * never a reason to block a call.
+ *
+ * Defaults are intentionally conservative and clearly approximate; they are
+ * overridable via `config.governance.priceTable`. They are a best-effort
+ * estimate and WILL drift from real provider pricing — treat USD as a guide,
+ * tokens as the source of truth.
+ */
+
+import { logger } from '../utils/logger.js';
+import type { ModelPrice, PriceTable } from './types.js';
+
+const log = logger.child('governance:price');
+
+/**
+ * Built-in default price table (USD per 1M tokens). Approximate, as of the
+ * 2025 public list prices. Override per-deployment via config.
+ */
+export const DEFAULT_PRICE_TABLE: PriceTable = {
+  anthropic: {
+    'claude-3-5-haiku*': { inputPerMTok: 0.8, outputPerMTok: 4 },
+    'claude-3-haiku*': { inputPerMTok: 0.25, outputPerMTok: 1.25 },
+    'claude-3-5-sonnet*': { inputPerMTok: 3, outputPerMTok: 15 },
+    'claude-3-7-sonnet*': { inputPerMTok: 3, outputPerMTok: 15 },
+    'claude-sonnet*': { inputPerMTok: 3, outputPerMTok: 15 },
+    'claude-3-opus*': { inputPerMTok: 15, outputPerMTok: 75 },
+    'claude-opus*': { inputPerMTok: 15, outputPerMTok: 75 },
+    'claude-*': { inputPerMTok: 3, outputPerMTok: 15 },
+  },
+  openai: {
+    'gpt-4o-mini*': { inputPerMTok: 0.15, outputPerMTok: 0.6 },
+    'gpt-4o*': { inputPerMTok: 2.5, outputPerMTok: 10 },
+    'gpt-4.1-mini*': { inputPerMTok: 0.4, outputPerMTok: 1.6 },
+    'gpt-4.1*': { inputPerMTok: 2, outputPerMTok: 8 },
+    'gpt-4-turbo*': { inputPerMTok: 10, outputPerMTok: 30 },
+    'o1*': { inputPerMTok: 15, outputPerMTok: 60 },
+    'o3-mini*': { inputPerMTok: 1.1, outputPerMTok: 4.4 },
+    'gpt-*': { inputPerMTok: 2.5, outputPerMTok: 10 },
+  },
+  // Local models — no marginal API cost. Tokens are still aggregated.
+  ollama: {
+    '*': { inputPerMTok: 0, outputPerMTok: 0 },
+  },
+};
+
+const ZERO_PRICE: ModelPrice = { inputPerMTok: 0, outputPerMTok: 0 };
+
+/** Track which (provider/model) combos we've already warned about. */
+const warnedUnknown = new Set<string>();
+
+/**
+ * Compile a glob (only `*` and `?` are special) into a RegExp anchored on both
+ * ends. Used for both provider and model matching.
+ */
+function globToRegExp(glob: string): RegExp {
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*/g, '.*')
+    .replace(/\?/g, '.');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+/**
+ * Merge a user-supplied override table over the defaults. Overrides are merged
+ * per provider so a user can add or replace individual model entries without
+ * having to restate the whole built-in table.
+ */
+export function mergePriceTable(overrides?: PriceTable): PriceTable {
+  if (!overrides) return DEFAULT_PRICE_TABLE;
+  const merged: PriceTable = {};
+  const providers = new Set([
+    ...Object.keys(DEFAULT_PRICE_TABLE),
+    ...Object.keys(overrides),
+  ]);
+  for (const provider of providers) {
+    const lower = provider.toLowerCase();
+    merged[lower] = {
+      ...(DEFAULT_PRICE_TABLE[provider] ?? DEFAULT_PRICE_TABLE[lower] ?? {}),
+      ...(overrides[provider] ?? overrides[lower] ?? {}),
+    };
+  }
+  return merged;
+}
+
+/**
+ * Resolve the price for a (provider, model) pair. The longest matching model
+ * pattern (most specific) wins. Returns a zero price + warns when nothing
+ * matches.
+ */
+export function resolvePrice(
+  table: PriceTable,
+  provider: string,
+  model: string,
+): ModelPrice {
+  const providerKey = Object.keys(table).find(
+    (k) => k.toLowerCase() === provider.toLowerCase(),
+  );
+  const models = providerKey ? table[providerKey] : undefined;
+
+  if (models) {
+    // Sort patterns by specificity (longer, fewer wildcards first) so exact and
+    // narrow globs beat the catch-all `*`.
+    const patterns = Object.keys(models).sort((a, b) => {
+      const aw = (a.match(/\*/g) ?? []).length;
+      const bw = (b.match(/\*/g) ?? []).length;
+      if (aw !== bw) return aw - bw;
+      return b.length - a.length;
+    });
+    for (const pattern of patterns) {
+      if (globToRegExp(pattern).test(model)) {
+        return models[pattern];
+      }
+    }
+  }
+
+  const cacheKey = `${provider}/${model}`;
+  if (!warnedUnknown.has(cacheKey)) {
+    warnedUnknown.add(cacheKey);
+    log.warn('No price entry for model — USD cost will be 0 (tokens still counted)', {
+      provider,
+      model,
+    });
+  }
+  return ZERO_PRICE;
+}
+
+/**
+ * Estimate the USD cost of a call given resolved token counts and a price.
+ */
+export function estimateUsdCost(
+  price: ModelPrice,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const usd =
+    (inputTokens / 1_000_000) * price.inputPerMTok +
+    (outputTokens / 1_000_000) * price.outputPerMTok;
+  // Round to 6 decimals to avoid float dust in stored/reported values.
+  return Math.round(usd * 1e6) / 1e6;
+}
+
+/** Reset the warn cache (testing only). */
+export function _resetPriceWarnings(): void {
+  warnedUnknown.clear();
+}

--- a/src/governance/service.ts
+++ b/src/governance/service.ts
@@ -1,0 +1,183 @@
+/**
+ * GovernanceService (AIG-867).
+ *
+ * Composes the price table, aggregator and enforcer behind two call-site
+ * methods used by the spawner:
+ *
+ *   - `checkBudget(ctx)`  — pre-call; may throw CostBudgetExceededError when
+ *                           `enforce.block` is on and the budget is at 100%.
+ *   - `recordSpend(...)`  — post-call; computes USD from the price table and
+ *                           appends a ledger row, then re-evaluates to emit
+ *                           warn/block audit events.
+ *
+ * SECURITY DEFAULT: when `config.governance.enabled` is false the service is
+ * never constructed (see index.ts) — there is no runtime cost. Even when
+ * enabled, blocking requires `enforce.block: true`.
+ */
+
+import type Database from 'better-sqlite3';
+import type { AgentStackConfig } from '../types.js';
+import { logger } from '../utils/logger.js';
+import { CostAggregator } from './aggregator.js';
+import { BudgetEnforcer } from './enforcer.js';
+import {
+  estimateUsdCost,
+  mergePriceTable,
+  resolvePrice,
+} from './price-table.js';
+import {
+  DEFAULT_BUCKET,
+  type BudgetCheckContext,
+  type BudgetEvaluation,
+  type GovernanceConfig,
+  type PriceTable,
+  type SpendQuery,
+  type SpendRecord,
+  type SpendReport,
+} from './types.js';
+
+const log = logger.child('governance');
+
+/**
+ * Thrown by the spawner (via GovernanceService.checkBudget) when a budget is at
+ * or above 100% and hard blocking is enabled. Carries the evaluation so callers
+ * and audit handlers can report the offending budget.
+ */
+export class CostBudgetExceededError extends Error {
+  constructor(public readonly evaluation: BudgetEvaluation) {
+    const id = evaluation.budget?.id ?? 'unnamed budget';
+    super(
+      `cost budget exceeded (${id}): ${Math.round(evaluation.percent)}% of cap ` +
+        `(spend $${evaluation.currentUsd.toFixed(4)}, ${evaluation.currentTokens} tokens)`,
+    );
+    this.name = 'CostBudgetExceededError';
+  }
+}
+
+/** Input for a post-call spend record (usage + attribution metadata). */
+export interface RecordSpendInput {
+  inputTokens: number;
+  outputTokens: number;
+  provider: string;
+  model: string;
+  agentType?: string;
+  project?: string;
+  tenantId?: string;
+  workspaceId?: string;
+  ts?: number;
+}
+
+export class GovernanceService {
+  private config: AgentStackConfig;
+  private governance: GovernanceConfig;
+  private priceTable: PriceTable;
+  private aggregator: CostAggregator;
+  private enforcer: BudgetEnforcer;
+
+  constructor(config: AgentStackConfig, db: Database.Database) {
+    this.config = config;
+    this.governance = config.governance ?? { enabled: false };
+    this.priceTable = mergePriceTable(this.governance.priceTable);
+    this.aggregator = new CostAggregator(db);
+    this.enforcer = new BudgetEnforcer(config, this.governance, this.aggregator);
+  }
+
+  /** Whether the module is active. */
+  isEnabled(): boolean {
+    return this.governance.enabled === true;
+  }
+
+  /**
+   * Pre-call budget check. No-op when disabled. Evaluates the matching budget
+   * and, only when `enforce.block` is true and the budget is at 100%, throws
+   * CostBudgetExceededError to prevent the LLM call. Otherwise (warn / observe)
+   * it returns the evaluation without throwing.
+   */
+  checkBudget(ctx: BudgetCheckContext): BudgetEvaluation {
+    if (!this.isEnabled()) {
+      return { state: 'ok', currentUsd: 0, currentTokens: 0, percent: 0 };
+    }
+    const evaluation = this.enforcer.evaluate(ctx);
+    if (evaluation.state === 'block' && this.enforcer.isBlockEnabled()) {
+      throw new CostBudgetExceededError(evaluation);
+    }
+    return evaluation;
+  }
+
+  /**
+   * Post-call accounting. No-op when disabled. Computes the estimated USD cost
+   * from the price table, appends a ledger row, then re-evaluates the budget so
+   * threshold-crossing warn/block audit events fire.
+   */
+  recordSpend(input: RecordSpendInput): void {
+    if (!this.isEnabled()) return;
+    // Nothing to record if the provider didn't return usage.
+    if (!input.inputTokens && !input.outputTokens) return;
+
+    const price = resolvePrice(this.priceTable, input.provider, input.model);
+    const usdCost = estimateUsdCost(price, input.inputTokens, input.outputTokens);
+
+    const record: SpendRecord = {
+      ts: input.ts,
+      tenantId: input.tenantId ?? DEFAULT_BUCKET,
+      workspaceId: input.workspaceId,
+      project: input.project ?? DEFAULT_BUCKET,
+      agentType: input.agentType ?? DEFAULT_BUCKET,
+      provider: input.provider,
+      model: input.model,
+      inputTokens: input.inputTokens,
+      outputTokens: input.outputTokens,
+      usdCost,
+    };
+    this.aggregator.recordSpend(record);
+
+    // Re-evaluate so a freshly-crossed threshold emits its audit event. This is
+    // observe-only on the post-call path — it never throws.
+    try {
+      this.enforcer.evaluate({
+        tenantId: input.tenantId,
+        workspaceId: input.workspaceId,
+        project: input.project,
+        agentType: input.agentType,
+      });
+    } catch (err) {
+      log.warn('Post-call budget evaluation failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Grouped spend report. Works regardless of enabled state (read-only). */
+  getReport(query: SpendQuery): SpendReport {
+    return this.aggregator.querySpend(query);
+  }
+
+  /** Status summary for the CLI / REST `status` endpoint. */
+  getStatus(): {
+    enabled: boolean;
+    blockEnabled: boolean;
+    warnThresholdPercent: number;
+    window: string;
+    budgets: number;
+    ledgerRows: number;
+  } {
+    return {
+      enabled: this.isEnabled(),
+      blockEnabled: this.enforcer.isBlockEnabled(),
+      warnThresholdPercent: this.governance.enforce?.warnThresholdPercent ?? 80,
+      window: this.governance.window ?? 'month',
+      budgets: (this.governance.budgets ?? []).length,
+      ledgerRows: this.aggregator.count(),
+    };
+  }
+
+  /** Expose budgets for the REST `/budgets` endpoint. */
+  getBudgets(): GovernanceConfig['budgets'] {
+    return this.governance.budgets ?? [];
+  }
+
+  /** Direct aggregator access (testing / advanced callers). */
+  getAggregator(): CostAggregator {
+    return this.aggregator;
+  }
+}

--- a/src/governance/span-adapter.ts
+++ b/src/governance/span-adapter.ts
@@ -1,0 +1,89 @@
+/**
+ * Optional OTel SpanProcessor adapter (AIG-867) — secondary attribution path.
+ *
+ * Today aistack does NOT wire an in-process SpanProcessor: spans produced by
+ * `traceAsync` go straight to the OTLP exporter (see src/observability/tracing.ts).
+ * The PRIMARY spend-attribution path is therefore in-code at the spawner call
+ * site (governanceService.recordSpend after the `aistack.llm.chat` span), which
+ * is the single point where `llm.usage.*` is known.
+ *
+ * This adapter is provided for completeness: if a deployment ever registers an
+ * in-process SpanProcessor, it can convert `aistack.llm.chat` spans into spend
+ * records too. To avoid DOUBLE COUNTING it must be MUTUALLY EXCLUSIVE with the
+ * in-code path — register at most one of them. It is NOT wired by default.
+ *
+ * The adapter is typed structurally so it has no hard dependency on the OTel SDK
+ * surface; it is compatible with `@opentelemetry/sdk-trace-base`'s SpanProcessor.
+ */
+
+import type { AgentStackConfig } from '../types.js';
+import { logger } from '../utils/logger.js';
+import { getGovernanceService } from './index.js';
+
+const log = logger.child('governance:span');
+
+/** Minimal structural view of a finished OTel span. */
+interface ReadableSpanLike {
+  name: string;
+  attributes: Record<string, unknown>;
+}
+
+function num(v: unknown): number {
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.length > 0 ? v : undefined;
+}
+
+/**
+ * SpanProcessor that converts `aistack.llm.chat` spans into spend records.
+ * Implements the OTel SpanProcessor contract structurally (onStart/onEnd/
+ * shutdown/forceFlush).
+ */
+export class GovernanceSpanProcessor {
+  constructor(private readonly config: AgentStackConfig) {}
+
+  onStart(): void {
+    // no-op
+  }
+
+  onEnd(span: ReadableSpanLike): void {
+    if (span.name !== 'aistack.llm.chat') return;
+    const service = getGovernanceService(this.config);
+    if (!service?.isEnabled()) return;
+
+    const attrs = span.attributes;
+    const inputTokens = num(attrs['llm.usage.input_tokens']);
+    const outputTokens = num(attrs['llm.usage.output_tokens']);
+    if (!inputTokens && !outputTokens) return;
+
+    try {
+      service.recordSpend({
+        inputTokens,
+        outputTokens,
+        provider: str(attrs['llm.provider']) ?? 'unknown',
+        model:
+          str(attrs['llm.response.model']) ??
+          str(attrs['llm.request.model']) ??
+          'unknown',
+        agentType: str(attrs['agent.type']),
+        tenantId: str(attrs['tenant.id']),
+        workspaceId: str(attrs['workspace.id']),
+      });
+    } catch (err) {
+      log.warn('Span->spend conversion failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async forceFlush(): Promise<void> {
+    // spend is written synchronously on onEnd; nothing to flush.
+  }
+
+  async shutdown(): Promise<void> {
+    // no resources to release.
+  }
+}

--- a/src/governance/types.ts
+++ b/src/governance/types.ts
@@ -1,0 +1,120 @@
+/**
+ * Cost governance types (AIG-867).
+ *
+ * A thin governance layer that derives spend (tokens + estimated USD) from the
+ * same usage signal the OTel `aistack.llm.chat` span already carries, attributes
+ * it per tenant/workspace/project/agent-pattern, and enforces optional budget
+ * caps with a two-stage kill-switch (warn -> block).
+ *
+ * SECURITY DEFAULT: the whole module is opt-in. `enabled: false` (default) makes
+ * every entry point a no-op, and `enforce.block` is additionally `false` by
+ * default so that turning governance on starts in observe-only / warn mode.
+ * This mirrors the guardrails (AIG-868), audit (AIG-635) and tracing modules,
+ * all of which are off by default.
+ */
+
+// Config-shaped types live in the root types module (single source of truth,
+// referenced by AgentStackConfig.governance). Re-exported here so governance
+// code can import everything from one place.
+export type {
+  ModelPrice,
+  PriceTable,
+  BudgetWindow,
+  CostBudgetScope,
+  CostBudget,
+  GovernanceEnforceConfig,
+  GovernanceConfig,
+} from '../types.js';
+
+/** Dimension a spend report can be grouped by. */
+export type SpendDimension = 'tenant' | 'workspace' | 'project' | 'agent';
+
+/**
+ * A normalized spend event derived from one LLM call. Persisted as a row in the
+ * `cost_ledger` table and the unit of aggregation for reports.
+ */
+export interface SpendRecord {
+  /** Epoch millis the spend occurred. Defaults to now() when omitted. */
+  ts?: number;
+  /** Resolved tenant id, or `__default__` in single-tenant mode. */
+  tenantId?: string;
+  /** Resolved workspace id, or null. */
+  workspaceId?: string;
+  /** Project label (free-form), or `__default__`. */
+  project?: string;
+  /** Concrete agent type (e.g. `coder`) used for agent-pattern attribution. */
+  agentType?: string;
+  /** Provider name (e.g. `anthropic`). */
+  provider: string;
+  /** Model id (request or response model). */
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  /** Estimated USD cost; computed from the price table when omitted. */
+  usdCost?: number;
+}
+
+/** One grouped row of a spend report. */
+export interface SpendReportRow {
+  /** The dimension key (tenant id / workspace id / project / agent type). */
+  key: string;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  usdCost: number;
+  /** Number of LLM calls aggregated into this row. */
+  calls: number;
+}
+
+/** Result of a spend query. */
+export interface SpendReport {
+  dimension: SpendDimension;
+  from?: number;
+  to?: number;
+  rows: SpendReportRow[];
+  totals: {
+    inputTokens: number;
+    outputTokens: number;
+    totalTokens: number;
+    usdCost: number;
+    calls: number;
+  };
+}
+
+/** Filters accepted by the aggregator query. */
+export interface SpendQuery {
+  dimension: SpendDimension;
+  /** Inclusive lower bound (epoch millis). */
+  from?: number;
+  /** Inclusive upper bound (epoch millis). */
+  to?: number;
+  tenantId?: string;
+  workspaceId?: string;
+  project?: string;
+}
+
+/** Context passed to a pre-call budget check. */
+export interface BudgetCheckContext {
+  tenantId?: string;
+  workspaceId?: string;
+  project?: string;
+  agentType?: string;
+}
+
+/** Enforcement state for a budget check. */
+export type BudgetState = 'ok' | 'warn' | 'block';
+
+/** Outcome of a budget evaluation. */
+export interface BudgetEvaluation {
+  state: BudgetState;
+  /** The budget that produced the highest-severity state, if any matched. */
+  budget?: CostBudget;
+  /** Current spend in the window, in USD and tokens. */
+  currentUsd: number;
+  currentTokens: number;
+  /** Percentage of the tripped limit reached (0..n). */
+  percent: number;
+}
+
+/** Sentinel used when no tenant/workspace/project is resolvable. */
+export const DEFAULT_BUCKET = '__default__';

--- a/src/governance/types.ts
+++ b/src/governance/types.ts
@@ -14,8 +14,11 @@
  */
 
 // Config-shaped types live in the root types module (single source of truth,
-// referenced by AgentStackConfig.governance). Re-exported here so governance
-// code can import everything from one place.
+// referenced by AgentStackConfig.governance). Imported here for local use in
+// the report/runtime types below, and re-exported so governance code can import
+// everything from one place.
+import type { CostBudget } from '../types.js';
+
 export type {
   ModelPrice,
   PriceTable,

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,3 +255,41 @@ export {
   type GuardrailAuditEvent,
   type WithGuardrailsOptions,
 } from './guardrails/index.js';
+
+// Cost Governance (AIG-867)
+export {
+  // Facade
+  initGovernance,
+  getGovernanceService,
+  recordSpend,
+  resetGovernanceService,
+  // Core
+  GovernanceService,
+  CostBudgetExceededError,
+  CostAggregator,
+  BudgetEnforcer,
+  windowStart,
+  // Price table
+  DEFAULT_PRICE_TABLE,
+  resolvePrice,
+  estimateUsdCost,
+  mergePriceTable,
+  DEFAULT_BUCKET,
+  // Types
+  type GovernanceConfig,
+  type GovernanceEnforceConfig,
+  type CostBudget,
+  type CostBudgetScope,
+  type BudgetWindow,
+  type BudgetState,
+  type BudgetEvaluation,
+  type BudgetCheckContext,
+  type ModelPrice,
+  type PriceTable,
+  type SpendDimension,
+  type SpendRecord,
+  type SpendReport,
+  type SpendReportRow,
+  type SpendQuery,
+  type RecordSpendInput,
+} from './governance/index.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -362,6 +362,8 @@ export interface AgentStackConfig {
   /** Authentication config (extended for SSO via auth.sso sub-field). AIG-646. */
   auth?: AuthConfig;
   federation?: FederationConfig;
+  /** Cost / budget governance over OTel usage + multitenancy (AIG-867). */
+  governance?: GovernanceConfig;
 }
 
 /**
@@ -412,6 +414,60 @@ export interface MultitenancyConfig {
   enabled: boolean;
   defaultTenantSlug: string;
   defaultWorkspaceSlug: string;
+}
+
+// ===== Cost governance configuration (AIG-867) ==========================
+//
+// Opt-in cost-governance layer. `enabled: false` (default) makes the whole
+// module a no-op; `enforce.block: false` (default) keeps it observe-only even
+// when enabled. See src/governance/ and docs/GOVERNANCE.md.
+
+/** USD-per-million-token pricing for a (provider, model). */
+export interface ModelPrice {
+  inputPerMTok: number;
+  outputPerMTok: number;
+}
+
+/** provider -> (model-glob -> price). */
+export type PriceTable = Record<string, Record<string, ModelPrice>>;
+
+/** Budget window granularity. `total` = all-time / no reset. */
+export type BudgetWindow = 'day' | 'week' | 'month' | 'total';
+
+/** Scope selector for a budget cap (glob on agentPattern). */
+export interface CostBudgetScope {
+  tenant?: string;
+  workspace?: string;
+  project?: string;
+  agentPattern?: string;
+}
+
+/** A single budget cap (USD and/or tokens) over a window. */
+export interface CostBudget {
+  id?: string;
+  scope?: CostBudgetScope;
+  limitUsd?: number;
+  limitTokens?: number;
+  window?: BudgetWindow;
+}
+
+/** Kill-switch settings (warn -> block). */
+export interface GovernanceEnforceConfig {
+  /** Hard-block at 100%. Default false (observe-only). */
+  block: boolean;
+  /** Percentage at which a warn event fires. Default 80. */
+  warnThresholdPercent: number;
+}
+
+/** Top-level governance configuration. */
+export interface GovernanceConfig {
+  /** Master switch. Default false — module is a no-op when disabled. */
+  enabled: boolean;
+  priceTable?: PriceTable;
+  budgets?: CostBudget[];
+  enforce?: GovernanceEnforceConfig;
+  /** Default budget window. Default `month`. */
+  window?: BudgetWindow;
 }
 
 // AIG-636 — daemon (background headless runner) config. Optional sibling field.

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -308,6 +308,46 @@ const AuditConfigSchema = z.object({
 });
 
 /**
+ * Cost Governance Configuration Schema (AIG-867)
+ *
+ * Opt-in cost/budget governance over OTel usage + multitenancy. Disabled by
+ * default; `enforce.block` is additionally false by default so the module is
+ * observe-only (accounting + warn) until blocking is explicitly enabled.
+ */
+const ModelPriceSchema = z.object({
+  inputPerMTok: z.number().min(0),
+  outputPerMTok: z.number().min(0),
+});
+
+const CostBudgetSchema = z.object({
+  id: z.string().optional(),
+  scope: z
+    .object({
+      tenant: z.string().optional(),
+      workspace: z.string().optional(),
+      project: z.string().optional(),
+      agentPattern: z.string().optional(),
+    })
+    .optional(),
+  limitUsd: z.number().min(0).optional(),
+  limitTokens: z.number().min(0).optional(),
+  window: z.enum(['day', 'week', 'month', 'total']).optional(),
+});
+
+const GovernanceConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  priceTable: z.record(z.string(), z.record(z.string(), ModelPriceSchema)).optional(),
+  budgets: z.array(CostBudgetSchema).optional(),
+  enforce: z
+    .object({
+      block: z.boolean().default(false),
+      warnThresholdPercent: z.number().min(0).max(100).default(80),
+    })
+    .default({}),
+  window: z.enum(['day', 'week', 'month', 'total']).default('month'),
+});
+
+/**
  * Sandbox Configuration Schema (AIG-634)
  *
  * Controls sandboxed code execution for the coder agent and any caller of
@@ -587,6 +627,7 @@ const ConfigSchema = z.object({
   guardrails: GuardrailsConfigSchema.default({}),
   auth: AuthConfigSchema.optional(),
   federation: FederationConfigSchema.default({}),
+  governance: GovernanceConfigSchema.default({}),
 });
 
 const CONFIG_FILE_NAME = 'aistack.config.json';

--- a/src/web/routes/governance.ts
+++ b/src/web/routes/governance.ts
@@ -1,0 +1,87 @@
+/**
+ * Cost governance REST routes (AIG-867).
+ *
+ * Endpoints (all read-only — governance is configured via config, not the API):
+ *   GET /api/v1/governance/status   — module enabled/block state + summary
+ *   GET /api/v1/governance/budgets  — configured budgets
+ *   GET /api/v1/governance/spend    — grouped spend report
+ *       ?dimension=tenant|workspace|project|agent (default tenant)
+ *       &from=<ms|ISO>&to=<ms|ISO>&tenantId=&workspaceId=&project=
+ *
+ * When governance is disabled all endpoints return `{ enabled: false, ... }`
+ * (mirrors the resources endpoint), never an error.
+ */
+
+import type { AgentStackConfig } from '../../types.js';
+import type { Router } from '../router.js';
+import { sendJson } from '../router.js';
+import { getGovernanceService } from '../../governance/index.js';
+import type { SpendDimension } from '../../governance/index.js';
+
+const VALID_DIMENSIONS: SpendDimension[] = ['tenant', 'workspace', 'project', 'agent'];
+
+/** Parse an epoch-millis or ISO-8601 timestamp; returns undefined if absent/invalid. */
+function parseTs(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  if (/^\d+$/.test(raw)) return Number(raw);
+  const ms = Date.parse(raw);
+  return Number.isNaN(ms) ? undefined : ms;
+}
+
+export function registerGovernanceRoutes(router: Router, config: AgentStackConfig): void {
+  // GET /api/v1/governance/status
+  router.get('/api/v1/governance/status', (_req, res) => {
+    const service = getGovernanceService(config);
+    if (!service) {
+      sendJson(res, { enabled: false, message: 'Cost governance not enabled' });
+      return;
+    }
+    sendJson(res, service.getStatus());
+  });
+
+  // GET /api/v1/governance/budgets
+  router.get('/api/v1/governance/budgets', (_req, res) => {
+    const service = getGovernanceService(config);
+    if (!service) {
+      sendJson(res, { enabled: false, budgets: [] });
+      return;
+    }
+    sendJson(res, { enabled: true, budgets: service.getBudgets() });
+  });
+
+  // GET /api/v1/governance/spend
+  router.get('/api/v1/governance/spend', (_req, res, params) => {
+    const service = getGovernanceService(config);
+    if (!service) {
+      sendJson(res, { enabled: false, message: 'Cost governance not enabled' });
+      return;
+    }
+
+    const dimRaw = (params.query.dimension as SpendDimension) || 'tenant';
+    if (!VALID_DIMENSIONS.includes(dimRaw)) {
+      sendJson(
+        res,
+        {
+          error: `invalid dimension "${dimRaw}" (use ${VALID_DIMENSIONS.join('|')})`,
+        },
+        400,
+      );
+      return;
+    }
+
+    try {
+      const report = service.getReport({
+        dimension: dimRaw,
+        from: parseTs(params.query.from),
+        to: parseTs(params.query.to),
+        tenantId: params.query.tenantId,
+        workspaceId: params.query.workspaceId,
+        project: params.query.project,
+      });
+      sendJson(res, { enabled: true, ...report });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to build spend report';
+      sendJson(res, { error: message }, 500);
+    }
+  });
+}

--- a/src/web/routes/index.ts
+++ b/src/web/routes/index.ts
@@ -18,3 +18,4 @@ export { registerIdentityRoutes } from './identities.js';
 export { registerConsensusRoutes } from './consensus.js';
 export { registerTenantRoutes } from './tenants.js';
 export { registerInterruptRoutes } from './interrupts.js';
+export { registerGovernanceRoutes } from './governance.js';

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -28,6 +28,7 @@ import {
   registerConsensusRoutes,
   registerTenantRoutes,
   registerInterruptRoutes,
+  registerGovernanceRoutes,
   registerSsoRoutes,
 } from './routes/index.js';
 import type { WebConfig } from './types.js';
@@ -125,6 +126,7 @@ export class WebServer {
     registerConsensusRoutes(this.router, this.config);
     registerTenantRoutes(this.router, this.config);
     registerInterruptRoutes(this.router, this.config);
+    registerGovernanceRoutes(this.router, this.config);
 
     // SSO routes (AIG-646) — registered only if any provider is configured.
     if (this.ssoModule) {

--- a/tests/integration/governance.test.ts
+++ b/tests/integration/governance.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Cost governance integration test (AIG-867).
+ *
+ * Exercises the public facade end-to-end against a real on-disk SQLite store,
+ * simulating the spawner's record/check flow:
+ *   - spend attribution per tenant/workspace/project/agent dimension,
+ *   - default-disabled no-op,
+ *   - kill-switch: NOT blocking by default (observe-only), blocking when
+ *     enforce.block is explicitly enabled.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { getDefaultConfig } from '../../src/utils/config.js';
+import {
+  getGovernanceService,
+  resetGovernanceService,
+  CostBudgetExceededError,
+} from '../../src/governance/index.js';
+import type { AgentStackConfig, GovernanceConfig } from '../../src/types.js';
+
+function configWith(governance: GovernanceConfig, dbPath: string): AgentStackConfig {
+  const config = getDefaultConfig();
+  config.memory.path = dbPath;
+  config.governance = governance;
+  return config;
+}
+
+describe('cost governance (integration)', () => {
+  let tmpDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'aistack-gov-test-'));
+    dbPath = join(tmpDir, 'gov.db');
+    resetGovernanceService();
+  });
+
+  afterEach(() => {
+    resetGovernanceService();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('is fully disabled by default (getDefaultConfig)', () => {
+    const config = getDefaultConfig();
+    config.memory.path = dbPath;
+    expect(config.governance?.enabled).toBe(false);
+    expect(getGovernanceService(config)).toBeNull();
+  });
+
+  it('attributes spend per tenant/workspace/project/agent', () => {
+    const config = configWith({ enabled: true }, dbPath);
+    const svc = getGovernanceService(config)!;
+    expect(svc).not.toBeNull();
+
+    // Simulate two LLM calls in different tenants/agents.
+    svc.recordSpend({
+      tenantId: 'tenant-a',
+      workspaceId: 'ws-1',
+      project: 'alpha',
+      agentType: 'coder',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-20241022',
+      inputTokens: 10_000,
+      outputTokens: 2_000,
+    });
+    svc.recordSpend({
+      tenantId: 'tenant-b',
+      workspaceId: 'ws-2',
+      project: 'beta',
+      agentType: 'reviewer',
+      provider: 'openai',
+      model: 'gpt-4o',
+      inputTokens: 5_000,
+      outputTokens: 1_000,
+    });
+
+    const byTenant = svc.getReport({ dimension: 'tenant' });
+    expect(byTenant.rows.map((r) => r.key).sort()).toEqual(['tenant-a', 'tenant-b']);
+    // tenant-a sonnet: (10000/1e6*3) + (2000/1e6*15) = 0.03 + 0.03 = 0.06
+    const a = byTenant.rows.find((r) => r.key === 'tenant-a')!;
+    expect(a.usdCost).toBeCloseTo(0.06, 6);
+
+    const byAgent = svc.getReport({ dimension: 'agent' });
+    expect(byAgent.rows.map((r) => r.key).sort()).toEqual(['coder', 'reviewer']);
+
+    const byProject = svc.getReport({ dimension: 'project' });
+    expect(byProject.rows.map((r) => r.key).sort()).toEqual(['alpha', 'beta']);
+
+    expect(byTenant.totals.totalTokens).toBe(18_000);
+  });
+
+  it('persists spend across service resets (shared SQLite store)', () => {
+    const config = configWith({ enabled: true }, dbPath);
+    getGovernanceService(config)!.recordSpend({
+      tenantId: 'tenant-a',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 1000,
+      outputTokens: 1000,
+    });
+    resetGovernanceService();
+
+    const svc2 = getGovernanceService(config)!;
+    expect(svc2.getReport({ dimension: 'tenant' }).totals.calls).toBe(1);
+  });
+
+  it('kill-switch: observe-only by default does NOT block over-budget calls', () => {
+    const config = configWith(
+      {
+        enabled: true,
+        window: 'total',
+        enforce: { block: false, warnThresholdPercent: 80 },
+        budgets: [
+          { id: 'cap-a', scope: { tenant: 'tenant-a' }, limitUsd: 0.01, window: 'total' },
+        ],
+      },
+      dbPath,
+    );
+    const svc = getGovernanceService(config)!;
+
+    // Spend well past the $0.01 cap.
+    svc.recordSpend({
+      tenantId: 'tenant-a',
+      agentType: 'coder',
+      provider: 'anthropic',
+      model: 'claude-3-opus',
+      inputTokens: 100_000,
+      outputTokens: 100_000,
+    });
+
+    // checkBudget reports block state but must NOT throw (block disabled).
+    const ev = svc.checkBudget({ tenantId: 'tenant-a', agentType: 'coder' });
+    expect(ev.state).toBe('block');
+    expect(() => svc.checkBudget({ tenantId: 'tenant-a', agentType: 'coder' })).not.toThrow();
+  });
+
+  it('kill-switch: blocks over-budget calls when enforce.block is enabled', () => {
+    const config = configWith(
+      {
+        enabled: true,
+        window: 'total',
+        enforce: { block: true, warnThresholdPercent: 80 },
+        budgets: [
+          { id: 'cap-a', scope: { tenant: 'tenant-a' }, limitUsd: 0.01, window: 'total' },
+        ],
+      },
+      dbPath,
+    );
+    const svc = getGovernanceService(config)!;
+
+    // Under budget initially: should not throw.
+    expect(() => svc.checkBudget({ tenantId: 'tenant-a', agentType: 'coder' })).not.toThrow();
+
+    // Drive spend over the cap, then the next pre-call check must throw.
+    svc.recordSpend({
+      tenantId: 'tenant-a',
+      agentType: 'coder',
+      provider: 'anthropic',
+      model: 'claude-3-opus',
+      inputTokens: 100_000,
+      outputTokens: 100_000,
+    });
+    expect(() => svc.checkBudget({ tenantId: 'tenant-a', agentType: 'coder' })).toThrow(
+      CostBudgetExceededError,
+    );
+
+    // A different tenant with no budget is unaffected.
+    expect(() => svc.checkBudget({ tenantId: 'tenant-b', agentType: 'coder' })).not.toThrow();
+  });
+
+  it('CLI providers without usage produce no ledger rows', () => {
+    const config = configWith({ enabled: true }, dbPath);
+    const svc = getGovernanceService(config)!;
+    svc.recordSpend({
+      tenantId: 'tenant-a',
+      provider: 'claude-code',
+      model: 'unknown',
+      inputTokens: 0,
+      outputTokens: 0,
+    });
+    expect(svc.getReport({ dimension: 'tenant' }).totals.calls).toBe(0);
+  });
+});

--- a/tests/unit/governance/aggregator.test.ts
+++ b/tests/unit/governance/aggregator.test.ts
@@ -1,0 +1,154 @@
+/**
+ * CostAggregator tests (AIG-867) — token aggregation + per-dimension attribution.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { CostAggregator } from '../../../src/governance/aggregator.js';
+import { DEFAULT_BUCKET } from '../../../src/governance/types.js';
+
+describe('CostAggregator', () => {
+  let db: Database.Database;
+  let agg: CostAggregator;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    agg = new CostAggregator(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  function seed(): void {
+    // tenant A / ws-1 / proj-x / coder
+    agg.recordSpend({
+      tenantId: 'tenant-a',
+      workspaceId: 'ws-1',
+      project: 'proj-x',
+      agentType: 'coder',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 1000,
+      outputTokens: 500,
+      usdCost: 0.0105,
+    });
+    // tenant A / ws-1 / proj-x / reviewer
+    agg.recordSpend({
+      tenantId: 'tenant-a',
+      workspaceId: 'ws-1',
+      project: 'proj-x',
+      agentType: 'reviewer',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 200,
+      outputTokens: 100,
+      usdCost: 0.0021,
+    });
+    // tenant B / ws-2 / proj-y / coder
+    agg.recordSpend({
+      tenantId: 'tenant-b',
+      workspaceId: 'ws-2',
+      project: 'proj-y',
+      agentType: 'coder',
+      provider: 'openai',
+      model: 'gpt-4o',
+      inputTokens: 4000,
+      outputTokens: 1000,
+      usdCost: 0.02,
+    });
+  }
+
+  it('aggregates tokens + USD grouped by tenant', () => {
+    seed();
+    const report = agg.querySpend({ dimension: 'tenant' });
+    expect(report.rows).toHaveLength(2);
+
+    const a = report.rows.find((r) => r.key === 'tenant-a')!;
+    expect(a.inputTokens).toBe(1200);
+    expect(a.outputTokens).toBe(600);
+    expect(a.totalTokens).toBe(1800);
+    expect(a.calls).toBe(2);
+    expect(a.usdCost).toBeCloseTo(0.0126, 6);
+
+    const b = report.rows.find((r) => r.key === 'tenant-b')!;
+    expect(b.totalTokens).toBe(5000);
+    expect(b.calls).toBe(1);
+  });
+
+  it('aggregates by workspace, project and agent dimensions', () => {
+    seed();
+    expect(agg.querySpend({ dimension: 'workspace' }).rows).toHaveLength(2);
+    expect(agg.querySpend({ dimension: 'project' }).rows).toHaveLength(2);
+
+    const byAgent = agg.querySpend({ dimension: 'agent' });
+    const coder = byAgent.rows.find((r) => r.key === 'coder')!;
+    // coder spans tenant A + tenant B
+    expect(coder.calls).toBe(2);
+    expect(coder.totalTokens).toBe(1500 + 5000);
+  });
+
+  it('computes report totals across rows', () => {
+    seed();
+    const report = agg.querySpend({ dimension: 'tenant' });
+    expect(report.totals.calls).toBe(3);
+    expect(report.totals.totalTokens).toBe(1800 + 5000);
+    expect(report.totals.usdCost).toBeCloseTo(0.0326, 6);
+  });
+
+  it('filters by time window in querySpend', () => {
+    const t0 = 1_000_000;
+    agg.recordSpend({
+      tenantId: 'tenant-a',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 100,
+      outputTokens: 100,
+      usdCost: 0.001,
+      ts: t0,
+    });
+    agg.recordSpend({
+      tenantId: 'tenant-a',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 100,
+      outputTokens: 100,
+      usdCost: 0.001,
+      ts: t0 + 10_000,
+    });
+    const recent = agg.querySpend({ dimension: 'tenant', from: t0 + 5_000 });
+    expect(recent.totals.calls).toBe(1);
+  });
+
+  it('sumSpend honours scope filters', () => {
+    seed();
+    const all = agg.sumSpend({});
+    expect(all.calls).toBe(3);
+
+    const justA = agg.sumSpend({ tenantId: 'tenant-a' });
+    expect(justA.calls).toBe(2);
+    expect(justA.inputTokens + justA.outputTokens).toBe(1800);
+
+    const justWs1Proj = agg.sumSpend({ tenantId: 'tenant-a', project: 'proj-x' });
+    expect(justWs1Proj.calls).toBe(2);
+  });
+
+  it('uses default buckets for missing tenant/project/agent', () => {
+    agg.recordSpend({
+      provider: 'ollama',
+      model: 'llama3',
+      inputTokens: 10,
+      outputTokens: 10,
+    });
+    const report = agg.querySpend({ dimension: 'tenant' });
+    expect(report.rows[0].key).toBe(DEFAULT_BUCKET);
+    // usdCost defaults to 0 when not supplied
+    expect(report.rows[0].usdCost).toBe(0);
+  });
+
+  it('schema bootstrap is idempotent (re-construct over same db)', () => {
+    seed();
+    const agg2 = new CostAggregator(db);
+    expect(agg2.count()).toBe(3);
+  });
+});

--- a/tests/unit/governance/enforcer.test.ts
+++ b/tests/unit/governance/enforcer.test.ts
@@ -6,7 +6,7 @@
  * fail-open for unknown models.
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 
 // Capture audit() calls without touching the real audit chain. Use vi.hoisted
@@ -151,8 +151,91 @@ describe('BudgetEnforcer', () => {
     });
   });
 
-  it('windowStart total returns 0', () => {
-    expect(windowStart('total')).toBe(0);
+  describe('windowStart', () => {
+    it('total returns 0', () => {
+      expect(windowStart('total')).toBe(0);
+    });
+
+    it('week is calendar-aligned (stable within the same ISO week)', () => {
+      // Two different instants within the same ISO week (Mon 2024-06-03 ..
+      // Sun 2024-06-09) must resolve to the same window start.
+      const monday = new Date(2024, 5, 3, 9, 0, 0).getTime(); // Mon 09:00 local
+      const sunday = new Date(2024, 5, 9, 23, 59, 0).getTime(); // Sun 23:59 local
+      const startMon = windowStart('week', monday);
+      const startSun = windowStart('week', sunday);
+      expect(startMon).toBe(startSun);
+      // Start is Monday 00:00 local of that week.
+      expect(startMon).toBe(new Date(2024, 5, 3, 0, 0, 0, 0).getTime());
+    });
+
+    it('week start is Monday 00:00 for every weekday', () => {
+      const expected = new Date(2024, 5, 3, 0, 0, 0, 0).getTime(); // Mon
+      for (let dow = 0; dow < 7; dow++) {
+        // 2024-06-03 is Monday; iterate Mon..Sun.
+        const instant = new Date(2024, 5, 3 + dow, 12, 0, 0).getTime();
+        expect(windowStart('week', instant)).toBe(expected);
+      }
+      // The next Monday rolls over to a new window start.
+      const nextMon = new Date(2024, 5, 10, 0, 0, 1).getTime();
+      expect(windowStart('week', nextMon)).toBe(
+        new Date(2024, 5, 10, 0, 0, 0, 0).getTime(),
+      );
+    });
+  });
+
+  describe('week-window audit idempotency', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    function setupWeek(spentUsd: number) {
+      const governance: GovernanceConfig = {
+        enabled: true,
+        enforce: { block: false, warnThresholdPercent: 80 },
+        budgets: [{ id: 'cap', scope: { tenant: 'a' }, limitUsd: 100, window: 'week' }],
+      };
+      agg.recordSpend({
+        tenantId: 'a',
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: spentUsd,
+      });
+      return new BudgetEnforcer(makeConfig(governance), governance, agg);
+    }
+
+    it('emits warn only once per week across repeated calls at different instants', () => {
+      vi.useFakeTimers();
+      // Tue 2024-06-04 within the ISO week starting Mon 2024-06-03.
+      vi.setSystemTime(new Date(2024, 5, 4, 10, 0, 0));
+      const e = setupWeek(85);
+
+      e.evaluate({ tenantId: 'a' });
+      // Advance time within the SAME ISO week; rolling-7d would have churned
+      // the dedup key here, calendar-aligned must not.
+      vi.setSystemTime(new Date(2024, 5, 6, 18, 0, 0)); // Thu, same week
+      e.evaluate({ tenantId: 'a' });
+      vi.setSystemTime(new Date(2024, 5, 9, 23, 0, 0)); // Sun, same week
+      e.evaluate({ tenantId: 'a' });
+
+      const warns = auditCalls.filter((c) => c.event === 'cost.budget.warn');
+      expect(warns).toHaveLength(1);
+    });
+
+    it('re-emits warn once the ISO week rolls over', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2024, 5, 6, 10, 0, 0)); // Thu, week of 06-03
+      const e = setupWeek(85);
+      e.evaluate({ tenantId: 'a' });
+
+      // Cross into the next ISO week (Mon 2024-06-10).
+      vi.setSystemTime(new Date(2024, 5, 11, 10, 0, 0)); // Tue, week of 06-10
+      e.evaluate({ tenantId: 'a' });
+
+      const warns = auditCalls.filter((c) => c.event === 'cost.budget.warn');
+      expect(warns).toHaveLength(2);
+    });
   });
 });
 

--- a/tests/unit/governance/enforcer.test.ts
+++ b/tests/unit/governance/enforcer.test.ts
@@ -9,8 +9,11 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import Database from 'better-sqlite3';
 
-// Capture audit() calls without touching the real audit chain.
-const auditCalls: Array<{ event: string; payload: Record<string, unknown> }> = [];
+// Capture audit() calls without touching the real audit chain. Use vi.hoisted
+// so the capture array exists before the hoisted vi.mock factory runs.
+const { auditCalls } = vi.hoisted(() => ({
+  auditCalls: [] as Array<{ event: string; payload: Record<string, unknown> }>,
+}));
 vi.mock('../../../src/audit/index.js', () => ({
   audit: (_config: unknown, event: string, payload: Record<string, unknown>) => {
     auditCalls.push({ event, payload });

--- a/tests/unit/governance/enforcer.test.ts
+++ b/tests/unit/governance/enforcer.test.ts
@@ -1,0 +1,247 @@
+/**
+ * BudgetEnforcer + GovernanceService tests (AIG-867).
+ *
+ * Covers: budget resolution by specificity, warn->block thresholds, audit event
+ * emission (idempotent), default-disabled no-op, block opt-in, and pricing
+ * fail-open for unknown models.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import Database from 'better-sqlite3';
+
+// Capture audit() calls without touching the real audit chain.
+const auditCalls: Array<{ event: string; payload: Record<string, unknown> }> = [];
+vi.mock('../../../src/audit/index.js', () => ({
+  audit: (_config: unknown, event: string, payload: Record<string, unknown>) => {
+    auditCalls.push({ event, payload });
+    return 1;
+  },
+}));
+
+import { CostAggregator } from '../../../src/governance/aggregator.js';
+import { BudgetEnforcer, windowStart } from '../../../src/governance/enforcer.js';
+import {
+  GovernanceService,
+  CostBudgetExceededError,
+} from '../../../src/governance/service.js';
+import type { AgentStackConfig, GovernanceConfig } from '../../../src/types.js';
+
+function makeConfig(governance: GovernanceConfig): AgentStackConfig {
+  // Only the fields the governance code touches are required.
+  return {
+    memory: { path: ':memory:' },
+    governance,
+  } as unknown as AgentStackConfig;
+}
+
+describe('BudgetEnforcer', () => {
+  let db: Database.Database;
+  let agg: CostAggregator;
+
+  beforeEach(() => {
+    auditCalls.length = 0;
+    db = new Database(':memory:');
+    agg = new CostAggregator(db);
+  });
+
+  describe('budget resolution', () => {
+    it('selects the most specific matching budget', () => {
+      const governance: GovernanceConfig = {
+        enabled: true,
+        budgets: [
+          { id: 'global', limitUsd: 100 },
+          { id: 'tenant-a', scope: { tenant: 'a' }, limitUsd: 50 },
+          { id: 'tenant-a-coder', scope: { tenant: 'a', agentPattern: 'coder' }, limitUsd: 10 },
+        ],
+      };
+      const enforcer = new BudgetEnforcer(makeConfig(governance), governance, agg);
+      const b = enforcer.resolveBudget({ tenantId: 'a', agentType: 'coder' });
+      expect(b?.id).toBe('tenant-a-coder');
+
+      const b2 = enforcer.resolveBudget({ tenantId: 'a', agentType: 'reviewer' });
+      expect(b2?.id).toBe('tenant-a');
+
+      const b3 = enforcer.resolveBudget({ tenantId: 'z', agentType: 'coder' });
+      expect(b3?.id).toBe('global');
+    });
+
+    it('returns undefined when no budget matches the tenant', () => {
+      const governance: GovernanceConfig = {
+        enabled: true,
+        budgets: [{ id: 'tenant-a', scope: { tenant: 'a' }, limitUsd: 50 }],
+      };
+      const enforcer = new BudgetEnforcer(makeConfig(governance), governance, agg);
+      expect(enforcer.resolveBudget({ tenantId: 'b' })).toBeUndefined();
+    });
+  });
+
+  describe('warn -> block thresholds', () => {
+    function setup(spentUsd: number) {
+      const governance: GovernanceConfig = {
+        enabled: true,
+        window: 'total',
+        enforce: { block: false, warnThresholdPercent: 80 },
+        budgets: [{ id: 'cap', scope: { tenant: 'a' }, limitUsd: 100, window: 'total' }],
+      };
+      // Seed spend for tenant a.
+      agg.recordSpend({
+        tenantId: 'a',
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: spentUsd,
+      });
+      const enforcer = new BudgetEnforcer(makeConfig(governance), governance, agg);
+      return enforcer;
+    }
+
+    it('ok below the warn threshold', () => {
+      const e = setup(50);
+      const ev = e.evaluate({ tenantId: 'a' });
+      expect(ev.state).toBe('ok');
+      expect(auditCalls).toHaveLength(0);
+    });
+
+    it('warn at/above warnThresholdPercent emits cost.budget.warn', () => {
+      const e = setup(85);
+      const ev = e.evaluate({ tenantId: 'a' });
+      expect(ev.state).toBe('warn');
+      expect(auditCalls.map((c) => c.event)).toContain('cost.budget.warn');
+    });
+
+    it('block at 100% emits cost.budget.block', () => {
+      const e = setup(120);
+      const ev = e.evaluate({ tenantId: 'a' });
+      expect(ev.state).toBe('block');
+      expect(auditCalls.map((c) => c.event)).toContain('cost.budget.block');
+      expect(ev.percent).toBeGreaterThanOrEqual(100);
+    });
+
+    it('audit emission is idempotent per window+stage', () => {
+      const e = setup(85);
+      e.evaluate({ tenantId: 'a' });
+      e.evaluate({ tenantId: 'a' });
+      e.evaluate({ tenantId: 'a' });
+      const warns = auditCalls.filter((c) => c.event === 'cost.budget.warn');
+      expect(warns).toHaveLength(1);
+    });
+  });
+
+  describe('token-based budgets', () => {
+    it('blocks when token cap is exceeded', () => {
+      const governance: GovernanceConfig = {
+        enabled: true,
+        window: 'total',
+        budgets: [{ id: 'tok', scope: { tenant: 'a' }, limitTokens: 1000, window: 'total' }],
+      };
+      agg.recordSpend({
+        tenantId: 'a',
+        provider: 'anthropic',
+        model: 'm',
+        inputTokens: 800,
+        outputTokens: 400,
+      });
+      const e = new BudgetEnforcer(makeConfig(governance), governance, agg);
+      const ev = e.evaluate({ tenantId: 'a' });
+      expect(ev.state).toBe('block');
+    });
+  });
+
+  it('windowStart total returns 0', () => {
+    expect(windowStart('total')).toBe(0);
+  });
+});
+
+describe('GovernanceService', () => {
+  beforeEach(() => {
+    auditCalls.length = 0;
+  });
+
+  it('is a no-op when disabled (checkBudget never throws, recordSpend stores nothing)', () => {
+    const db = new Database(':memory:');
+    const governance: GovernanceConfig = {
+      enabled: false,
+      enforce: { block: true, warnThresholdPercent: 80 },
+      budgets: [{ id: 'cap', scope: { tenant: 'a' }, limitUsd: 0.000001, window: 'total' }],
+    };
+    const svc = new GovernanceService(makeConfig(governance), db);
+
+    // Even with a tiny cap + block enabled, disabled => no throw, no record.
+    expect(() => svc.checkBudget({ tenantId: 'a', agentType: 'coder' })).not.toThrow();
+    svc.recordSpend({
+      tenantId: 'a',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 1000,
+      outputTokens: 1000,
+    });
+    expect(svc.getAggregator().count()).toBe(0);
+    db.close();
+  });
+
+  it('SECURITY DEFAULT: with block disabled, an over-budget call is NOT blocked', () => {
+    const db = new Database(':memory:');
+    const governance: GovernanceConfig = {
+      enabled: true,
+      window: 'total',
+      enforce: { block: false, warnThresholdPercent: 80 },
+      budgets: [{ id: 'cap', scope: { tenant: 'a' }, limitUsd: 0.0001, window: 'total' }],
+    };
+    const svc = new GovernanceService(makeConfig(governance), db);
+
+    // Drive spend over the cap.
+    svc.recordSpend({
+      tenantId: 'a',
+      agentType: 'coder',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 100_000,
+      outputTokens: 100_000,
+    });
+    // block disabled -> checkBudget returns block state but does not throw.
+    const ev = svc.checkBudget({ tenantId: 'a', agentType: 'coder' });
+    expect(ev.state).toBe('block');
+    db.close();
+  });
+
+  it('throws CostBudgetExceededError only when block is explicitly enabled', () => {
+    const db = new Database(':memory:');
+    const governance: GovernanceConfig = {
+      enabled: true,
+      window: 'total',
+      enforce: { block: true, warnThresholdPercent: 80 },
+      budgets: [{ id: 'cap', scope: { tenant: 'a' }, limitUsd: 0.0001, window: 'total' }],
+    };
+    const svc = new GovernanceService(makeConfig(governance), db);
+    svc.recordSpend({
+      tenantId: 'a',
+      agentType: 'coder',
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet',
+      inputTokens: 100_000,
+      outputTokens: 100_000,
+    });
+    expect(() => svc.checkBudget({ tenantId: 'a', agentType: 'coder' })).toThrow(
+      CostBudgetExceededError,
+    );
+    db.close();
+  });
+
+  it('records spend with fail-open pricing for unknown model (tokens kept, USD 0)', () => {
+    const db = new Database(':memory:');
+    const governance: GovernanceConfig = { enabled: true };
+    const svc = new GovernanceService(makeConfig(governance), db);
+    svc.recordSpend({
+      tenantId: 'a',
+      provider: 'mystery',
+      model: 'unknown-model',
+      inputTokens: 500,
+      outputTokens: 250,
+    });
+    const report = svc.getReport({ dimension: 'tenant' });
+    expect(report.totals.totalTokens).toBe(750);
+    expect(report.totals.usdCost).toBe(0);
+    db.close();
+  });
+});

--- a/tests/unit/governance/enforcer.test.ts
+++ b/tests/unit/governance/enforcer.test.ts
@@ -229,8 +229,19 @@ describe('BudgetEnforcer', () => {
       const e = setupWeek(85);
       e.evaluate({ tenantId: 'a' });
 
-      // Cross into the next ISO week (Mon 2024-06-10).
+      // Cross into the next ISO week (Mon 2024-06-10) and incur fresh spend
+      // inside that new window. The previous week's spend falls outside the
+      // calendar-aligned window, so the warn legitimately re-arms for the new
+      // week (a new dedup key, not stale rolling-7d churn).
       vi.setSystemTime(new Date(2024, 5, 11, 10, 0, 0)); // Tue, week of 06-10
+      agg.recordSpend({
+        tenantId: 'a',
+        provider: 'anthropic',
+        model: 'claude-3-5-sonnet',
+        inputTokens: 0,
+        outputTokens: 0,
+        usdCost: 85,
+      });
       e.evaluate({ tenantId: 'a' });
 
       const warns = auditCalls.filter((c) => c.event === 'cost.budget.warn');

--- a/tests/unit/governance/price-table.test.ts
+++ b/tests/unit/governance/price-table.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Price-table resolution tests (AIG-867).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  DEFAULT_PRICE_TABLE,
+  estimateUsdCost,
+  mergePriceTable,
+  resolvePrice,
+  _resetPriceWarnings,
+} from '../../../src/governance/price-table.js';
+
+describe('governance price-table', () => {
+  beforeEach(() => {
+    _resetPriceWarnings();
+  });
+
+  describe('resolvePrice', () => {
+    it('matches the most specific glob (sonnet beats claude-*)', () => {
+      const table = mergePriceTable();
+      const price = resolvePrice(table, 'anthropic', 'claude-3-5-sonnet-20241022');
+      expect(price.inputPerMTok).toBe(3);
+      expect(price.outputPerMTok).toBe(15);
+    });
+
+    it('falls back to the provider catch-all glob', () => {
+      const table = mergePriceTable();
+      const price = resolvePrice(table, 'anthropic', 'claude-some-future-model');
+      // claude-* catch-all
+      expect(price.inputPerMTok).toBe(3);
+    });
+
+    it('matches provider case-insensitively', () => {
+      const table = mergePriceTable();
+      const price = resolvePrice(table, 'OpenAI', 'gpt-4o-mini');
+      expect(price.inputPerMTok).toBe(0.15);
+    });
+
+    it('fail-open: unknown model/provider resolves to zero price', () => {
+      const table = mergePriceTable();
+      const price = resolvePrice(table, 'mystery-provider', 'mystery-model');
+      expect(price.inputPerMTok).toBe(0);
+      expect(price.outputPerMTok).toBe(0);
+    });
+
+    it('local provider (ollama) is priced at zero but resolvable', () => {
+      const table = mergePriceTable();
+      const price = resolvePrice(table, 'ollama', 'llama3.1:8b');
+      expect(price.inputPerMTok).toBe(0);
+    });
+  });
+
+  describe('mergePriceTable', () => {
+    it('overrides individual entries without dropping defaults', () => {
+      const merged = mergePriceTable({
+        anthropic: { 'claude-3-5-sonnet*': { inputPerMTok: 99, outputPerMTok: 199 } },
+      });
+      // overridden
+      expect(
+        resolvePrice(merged, 'anthropic', 'claude-3-5-sonnet-latest').inputPerMTok,
+      ).toBe(99);
+      // default still present
+      expect(resolvePrice(merged, 'openai', 'gpt-4o').inputPerMTok).toBe(2.5);
+    });
+
+    it('adds a brand-new provider', () => {
+      const merged = mergePriceTable({
+        custom: { '*': { inputPerMTok: 1, outputPerMTok: 2 } },
+      });
+      const p = resolvePrice(merged, 'custom', 'whatever');
+      expect(p.inputPerMTok).toBe(1);
+      expect(p.outputPerMTok).toBe(2);
+    });
+
+    it('returns defaults unchanged when no overrides given', () => {
+      expect(mergePriceTable()).toBe(DEFAULT_PRICE_TABLE);
+    });
+  });
+
+  describe('estimateUsdCost', () => {
+    it('computes per-million-token cost for input + output', () => {
+      const price = { inputPerMTok: 3, outputPerMTok: 15 };
+      // 1M input @ $3 + 1M output @ $15 = $18
+      expect(estimateUsdCost(price, 1_000_000, 1_000_000)).toBe(18);
+    });
+
+    it('handles fractional token counts', () => {
+      const price = { inputPerMTok: 3, outputPerMTok: 15 };
+      // 1000 input -> $0.003 ; 2000 output -> $0.03 ; total 0.033
+      expect(estimateUsdCost(price, 1000, 2000)).toBeCloseTo(0.033, 6);
+    });
+
+    it('zero price yields zero cost regardless of tokens', () => {
+      expect(estimateUsdCost({ inputPerMTok: 0, outputPerMTok: 0 }, 5000, 9000)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **cost-governance layer** on top of the existing OpenTelemetry usage signal (`src/observability/tracing.ts`) and multi-tenancy (`src/multitenancy/`). It derives spend (tokens + estimated USD) from each LLM call, attributes it per tenant / workspace / project / agent-pattern, and enforces optional budget caps with a two-stage kill-switch (warn → block).

The OTel span `aistack.llm.chat` already exposes `llm.usage.*`; the spawner already calls `resourceService.recordApiCall` right after it — that is the single point where token usage is known, so spend is recorded there (avoiding double counting from review-loop / consensus spans).

## Security default (opt-in, observe-only first)

- `config.governance.enabled` defaults to **false** → the whole module is a no-op (mirrors guardrails AIG-868, audit AIG-635, tracing — all off by default).
- `config.governance.enforce.block` defaults to **false** → even when enabled with a budget defined, an over-budget call is **never blocked**; it is only accounted and a `cost.budget.warn` / `cost.budget.block` audit event is emitted.
- Hard blocking at 100% requires **explicitly** setting `enforce.block: true`. A mis-configured budget can never take agents offline unless an operator opts in.

## Acceptance criteria

1. **Budget cap configurable per team/project/agent-pattern** — `config.governance.budgets[]` with hierarchical scope `{ tenant, workspace, project, agentPattern }` (glob on agent type); most-specific match wins; no budget = unlimited.
2. **Spend aggregation (tokens / estimated USD) from OTel spans, attributed per tenant/workspace** — `CostAggregator` persists one append-only `cost_ledger` row per call on the shared SQLite store; tenant/workspace read from agent metadata (AIG-649); reports grouped by tenant/workspace/project/agent.
3. **Kill-switch warn → block with audit log** — `BudgetEnforcer`: warn at `warnThresholdPercent` (default 80%) → block at 100%; emits `cost.budget.warn` / `cost.budget.block` via the hash-chained audit log (idempotent per budget+window); throws `CostBudgetExceededError` before the LLM call only when `enforce.block`.
4. **Report/endpoint to consult spend per dimension** — REST `GET /api/v1/governance/{status,budgets,spend?dimension=tenant|workspace|project|agent&from&to}` + `aistack governance {status,budgets,report}` CLI (JSON + table).
5. **Unit + integration tests** — `tests/unit/governance/{price-table,aggregator,enforcer}.test.ts` and `tests/integration/governance.test.ts` (token aggregation, tenant attribution, warn→block, default-disabled no-op, fail-open pricing, block opt-in).

## Design decisions (defaults documented in docs/GOVERNANCE.md)

- **Unit of cost** = tokens (input/output separate); USD estimated via a configurable price-table per `(provider, model)` glob (USD per 1M tokens). Unknown model → **USD 0** (fail-open) but tokens still aggregated + warn logged. Pricing is never a reason to block.
- **Scoping** = tenant/workspace (from `MultitenancyContext`) + project + agent-pattern; resolution by specificity.
- **Kill-switch** = warn 80% → block 100%, idempotent audit events per window.
- **Persistence** = append-only `cost_ledger` on `config.memory.path`, inline idempotent schema (mirrors `TenantService`); window `day|week|month|total` (default `month`).
- **Interface** = REST primary (existing web router + shared store) + minimal CLI for parity with `audit`/`tenant`.
- **Attribution site** = in-code at the spawner (single `llm.usage.*` point). An optional `GovernanceSpanProcessor` is provided as a secondary path but **not wired** (no in-process SpanProcessor is cabled today); it must be mutually exclusive with the in-code path to avoid double counting.

## Known limitations (see docs)

- Soft cap, not an atomic quota — concurrent calls between check and record can slightly overrun.
- Usage-bearing providers only (Anthropic/OpenAI/Ollama); CLI providers without `chatResponse.usage` aren't tracked.
- `cost_ledger` is append-only; retention/rollup is a follow-up (indexed by `(tenant, workspace, ts)`).

## Files (22)

New: `src/governance/{index,types,price-table,aggregator,enforcer,service,span-adapter}.ts`, `src/web/routes/governance.ts`, `src/cli/commands/governance.ts`, `tests/unit/governance/{price-table,aggregator,enforcer}.test.ts`, `tests/integration/governance.test.ts`, `docs/GOVERNANCE.md`.
Modified: `src/agents/spawner.ts`, `src/types.ts`, `src/utils/config.ts`, `src/index.ts`, `src/web/routes/index.ts`, `src/web/server.ts`, `src/cli/commands/index.ts`, `src/cli/index.ts`.

## CI note

This branch does **not** touch `.github/workflows/ci.yml` (changed in parallel by another branch). The new tests run under the existing `vitest` unit + integration suites — **no new CI step is required**. Validation (typecheck / test / lint) runs in CI on this PR (the dev environment has no Node).

## Manual smoke-test (relevant to AIG-866 sibling)

1. Set `governance.enabled: true` in `aistack.config.json` with a tenant-scoped `limitUsd` budget and `enforce.block: false`.
2. Run an agent that performs an LLM call (Anthropic/OpenAI). Verify `aistack governance report --dimension tenant` shows tokens + USD.
3. Drive spend past the cap; verify `cost.budget.warn` then `cost.budget.block` in `aistack audit export` (with audit enabled), and that agents are **not** blocked.
4. Set `enforce.block: true`; verify the next over-budget call throws `CostBudgetExceededError` before the LLM call.

Closes AIG-867
