### PR TITLE
[AIG-922] Fix on-prem Docker build: optional @xenova import no longer breaks tsc (TS2307)

### DIFF
--- a/src/memory/embedding/wasm/model-loader.ts
+++ b/src/memory/embedding/wasm/model-loader.ts
@@ -50,8 +50,13 @@ export function getModelsCacheDir(): string {
 export async function loadTransformersLibrary(): Promise<TransformersLibrary | null> {
   try {
     // Dynamic import so the optional dep does not break consumers that
-    // never opt into the WASM provider.
-    const mod = (await import('@xenova/transformers')) as unknown as TransformersLibrary;
+    // never opt into the WASM provider. The specifier is held in a variable on
+    // purpose: a non-literal argument stops `tsc` from statically resolving the
+    // optional module, so the build (e.g. the pruned on-prem Docker image where
+    // @xenova/transformers is absent) does not fail with TS2307. Availability is
+    // handled at runtime by the surrounding try/catch.
+    const specifier = '@xenova/transformers';
+    const mod = (await import(specifier)) as unknown as TransformersLibrary;
     return mod;
   } catch (err) {
     log.debug('Optional dependency @xenova/transformers not installed', {


### PR DESCRIPTION
## Summary
Fixes the **`coverage` job on `main`** (flaky-red, pre-existing): the on-prem `docker build` (`tests/integration/docker-helm.test.ts`, AIG-647) failed because `@xenova/transformers` — an **optionalDependency** (vector-WASM, AIG-653) with heavy native deps — fails to install in the slim image, so `tsc` hit `TS2307 Cannot find module` on the **literal** dynamic import at `src/memory/embedding/wasm/model-loader.ts:54`.

## Change (1 file, 1 import)
Hold the specifier in a variable so `tsc` does **not** statically resolve the optional module:
```ts
const specifier = '@xenova/transformers';
const mod = (await import(specifier)) as unknown as TransformersLibrary;
```
Runtime behaviour is unchanged — Node resolves the specifier at runtime and the surrounding try/catch already returns `null` when the dep is absent.

## Why this is not a regression from the recent merges
The `coverage` job is **main-only** (`if: push && ref==main`) and was already intermittently red before this session (e.g. main runs `de30879`/`1aa93ea` green, `19f44b3`/`7d9ec93` red). `docker-helm.test.ts` (AIG-647) and the `@xenova` import (AIG-653) pre-date AIG-852/854/855/866/867.

## Validation note
No PR job reproduces the "@xenova absent" condition (PR `Build` runs on ubuntu where the optional dep installs). The fix is validated by the **post-merge `coverage` run on main** (which runs the real docker build).

Closes AIG-922.